### PR TITLE
Update servicegraph key to service_graph

### DIFF
--- a/config/otel-collector-config.yaml
+++ b/config/otel-collector-config.yaml
@@ -37,7 +37,8 @@ connectors:
       - service.namespace
       - telemetry.sdk.language
 
-  servicegraph:
+  # "servicegraph:" in older versions of otel-collector
+  service_graph:
     latency_histogram_buckets: [2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms, 400ms, 800ms, 1s, 1.4s, 2s, 5s, 10s, 15s]
     dimensions:
       - db.system

--- a/docs/metrics-reference.md
+++ b/docs/metrics-reference.md
@@ -132,7 +132,8 @@ produces topology metrics showing which services call which.
 
 ```yaml
 connectors:
-  servicegraph:
+  service_graph:
+  # "servicegraph:: in older versions of otel-collector"
     latency_histogram_buckets:
       [2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms,
        400ms, 800ms, 1s, 1.4s, 2s, 5s, 10s, 15s]


### PR DESCRIPTION
Renamed 'servicegraph' to 'service_graph' for compatibility with newer versions:

```
'connectors' unknown type: "servicegraph" for id: "servicegraph" (valid values: [signal_to_metrics span_metrics spanmetrics sum forward count datadog otlpjson service_graph exceptions roundrobin signaltometrics failover grafanacloud routing])
```