### PR TITLE
feat: add ingress alias support for on-prem caller visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- **Ingress alias support** — Configurable hostname→service mapping makes on-prem (FSS) callers visible when they reach GCP services via nais ingress. For example, mapping `tilgangsmaskin.intern.nav.no → populasjonstilgangskontroll` reveals callers like oppgave and saf that were previously hidden. Backend expands caller queries with additional PromQL `or` clauses for each alias, and resolves aliased hostnames in the service map topology. Frontend adds a key-value editor in plugin settings for managing aliases.
+
 ## 0.10.1 (2026-05-07)
 
 ### Features

--- a/pkg/plugin/app.go
+++ b/pkg/plugin/app.go
@@ -99,14 +99,22 @@ func NewApp(_ context.Context, settings backend.AppInstanceSettings) (instancemg
 	}
 
 	// Build reverse ingress alias lookup: service_name → []hostnames.
+	// Normalize hostnames (lowercase, strip trailing dots, strip standard ports)
+	// so they match the normalized addresses produced by extractTopologyNodeName.
 	if len(app.settings.IngressAliases) > 0 {
+		normalized := make(map[string]string, len(app.settings.IngressAliases))
 		app.ingressByService = make(map[string][]string, len(app.settings.IngressAliases))
 		for hostname, svcName := range app.settings.IngressAliases {
-			if hostname != "" && svcName != "" {
-				app.ingressByService[svcName] = append(app.ingressByService[svcName], hostname)
+			if hostname == "" || svcName == "" {
+				continue
 			}
+			h := normalizeAddress(hostname)
+			svc := strings.TrimSpace(svcName)
+			normalized[h] = svc
+			app.ingressByService[svc] = append(app.ingressByService[svc], h)
 		}
-		logger.Info("Ingress aliases configured", "count", len(app.settings.IngressAliases), "services", len(app.ingressByService))
+		app.settings.IngressAliases = normalized
+		logger.Info("Ingress aliases configured", "count", len(normalized), "services", len(app.ingressByService))
 	}
 
 	// Read Grafana service account token from secureJsonData.

--- a/pkg/plugin/app.go
+++ b/pkg/plugin/app.go
@@ -42,6 +42,10 @@ type App struct {
 	capCache *cachedCapabilities
 
 	respCache *responseCache // short-lived response cache for expensive queries
+
+	// ingressByService maps service_name → list of ingress hostnames that route to it.
+	// Built from settings.IngressAliases (reversed). Used to expand caller queries.
+	ingressByService map[string][]string
 }
 
 // NewApp creates a new App instance, parsing datasource configuration from jsonData.
@@ -94,6 +98,17 @@ func NewApp(_ context.Context, settings backend.AppInstanceSettings) (instancemg
 		}
 	}
 
+	// Build reverse ingress alias lookup: service_name → []hostnames.
+	if len(app.settings.IngressAliases) > 0 {
+		app.ingressByService = make(map[string][]string, len(app.settings.IngressAliases))
+		for hostname, svcName := range app.settings.IngressAliases {
+			if hostname != "" && svcName != "" {
+				app.ingressByService[svcName] = append(app.ingressByService[svcName], hostname)
+			}
+		}
+		logger.Info("Ingress aliases configured", "count", len(app.settings.IngressAliases), "services", len(app.ingressByService))
+	}
+
 	// Read Grafana service account token from secureJsonData.
 	// When deployed behind an OAuth2 proxy (e.g., Wonderwall/Nais), the browser's
 	// session cookies are for the proxy, not for Grafana. Since the plugin backend
@@ -136,6 +151,14 @@ func NewApp(_ context.Context, settings backend.AppInstanceSettings) (instancemg
 
 // Dispose is called when the plugin instance is shut down.
 func (a *App) Dispose() {}
+
+// ingressHostnames returns the configured ingress hostnames for a service, or nil.
+func (a *App) ingressHostnames(service string) []string {
+	if a.ingressByService == nil {
+		return nil
+	}
+	return a.ingressByService[service]
+}
 
 // resolveInternalGrafanaURL builds the localhost URL for internal API calls.
 // The plugin runs in the same process/pod as Grafana, so we always use localhost

--- a/pkg/plugin/connected.go
+++ b/pkg/plugin/connected.go
@@ -129,12 +129,25 @@ func (a *App) queryConnectedServices(ctx context.Context, from, to time.Time, se
 			a.callsMetric(ctx), cfg.Labels.SpanKind, cfg.SpanKinds.Client,
 			cfg.Labels.ServerAddress, escapedHost, envLabelFilter, rangeStr,
 		)
+		smInRateQ += fmt.Sprintf(
+			` or sum by (%s, %s) (rate(%s{%s="%s", %s=~"%s(:[0-9]+)?"%s}%s))`,
+			cfg.Labels.ServiceName, cfg.Labels.ServiceNamespace,
+			a.callsMetric(ctx), cfg.Labels.SpanKind, cfg.SpanKinds.Client,
+			cfg.Labels.HTTPHost, escapedHost, envLabelFilter, rangeStr,
+		)
 		smInErrQ += fmt.Sprintf(
 			` or sum by (%s, %s) (rate(%s{%s="%s", %s="%s", %s=~"%s(:[0-9]+)?"%s}%s))`,
 			cfg.Labels.ServiceName, cfg.Labels.ServiceNamespace,
 			a.callsMetric(ctx), cfg.Labels.SpanKind, cfg.SpanKinds.Client,
 			cfg.Labels.StatusCode, cfg.StatusCodes.Error,
 			cfg.Labels.ServerAddress, escapedHost, envLabelFilter, rangeStr,
+		)
+		smInErrQ += fmt.Sprintf(
+			` or sum by (%s, %s) (rate(%s{%s="%s", %s="%s", %s=~"%s(:[0-9]+)?"%s}%s))`,
+			cfg.Labels.ServiceName, cfg.Labels.ServiceNamespace,
+			a.callsMetric(ctx), cfg.Labels.SpanKind, cfg.SpanKinds.Client,
+			cfg.Labels.StatusCode, cfg.StatusCodes.Error,
+			cfg.Labels.HTTPHost, escapedHost, envLabelFilter, rangeStr,
 		)
 	}
 

--- a/pkg/plugin/connected.go
+++ b/pkg/plugin/connected.go
@@ -119,6 +119,25 @@ func (a *App) queryConnectedServices(ctx context.Context, from, to time.Time, se
 		cfg.Labels.HTTPHost, escapedSvc, envLabelFilter, rangeStr,
 	)
 
+	// Ingress alias supplement: find callers via ingress hostnames configured
+	// as aliases for this service (e.g., on-prem callers using nais ingress).
+	for _, hostname := range a.ingressHostnames(service) {
+		escapedHost := promQLEscape(hostname)
+		smInRateQ += fmt.Sprintf(
+			` or sum by (%s, %s) (rate(%s{%s="%s", %s=~"%s(:[0-9]+)?"%s}%s))`,
+			cfg.Labels.ServiceName, cfg.Labels.ServiceNamespace,
+			a.callsMetric(ctx), cfg.Labels.SpanKind, cfg.SpanKinds.Client,
+			cfg.Labels.ServerAddress, escapedHost, envLabelFilter, rangeStr,
+		)
+		smInErrQ += fmt.Sprintf(
+			` or sum by (%s, %s) (rate(%s{%s="%s", %s="%s", %s=~"%s(:[0-9]+)?"%s}%s))`,
+			cfg.Labels.ServiceName, cfg.Labels.ServiceNamespace,
+			a.callsMetric(ctx), cfg.Labels.SpanKind, cfg.SpanKinds.Client,
+			cfg.Labels.StatusCode, cfg.StatusCodes.Error,
+			cfg.Labels.ServerAddress, escapedHost, envLabelFilter, rangeStr,
+		)
+	}
+
 	// Outbound spanmetrics supplement: discover external targets not in the
 	// service graph (e.g., Azure AD, APIs in other clusters). The service
 	// graph only generates edges when both client + server report to the same
@@ -219,7 +238,7 @@ func (a *App) queryConnectedServices(ctx context.Context, from, to time.Time, se
 		outboundNames[strings.ToLower(s.Name)] = true
 	}
 	for i := range smOutbound {
-		smOutbound[i].Name = extractTopologyNodeName(smOutbound[i].Name)
+		smOutbound[i].Name = a.resolveIngressAlias(extractTopologyNodeName(smOutbound[i].Name))
 		if smOutbound[i].Name == "" || smOutbound[i].Name == service || outboundNames[strings.ToLower(smOutbound[i].Name)] {
 			continue // already in service graph results, self-reference, or empty
 		}

--- a/pkg/plugin/handlers_test.go
+++ b/pkg/plugin/handlers_test.go
@@ -176,8 +176,8 @@ func TestHandleServices(t *testing.T) {
 				{
 					Metric: map[string]string{
 						cfg.Labels.ServiceName:      "frontend",
-						cfg.Labels.ServiceNamespace:  "otel-demo",
-						cfg.Labels.DeploymentEnv:     "production",
+						cfg.Labels.ServiceNamespace: "otel-demo",
+						cfg.Labels.DeploymentEnv:    "production",
 					},
 					Value: queries.NewPromValue(float64(now.Unix()), "10.5"),
 				},
@@ -186,8 +186,8 @@ func TestHandleServices(t *testing.T) {
 				{
 					Metric: map[string]string{
 						cfg.Labels.ServiceName:      "frontend",
-						cfg.Labels.ServiceNamespace:  "otel-demo",
-						cfg.Labels.DeploymentEnv:     "production",
+						cfg.Labels.ServiceNamespace: "otel-demo",
+						cfg.Labels.DeploymentEnv:    "production",
 					},
 					Value: queries.NewPromValue(float64(now.Unix()), "0.5"),
 				},
@@ -196,8 +196,8 @@ func TestHandleServices(t *testing.T) {
 				{
 					Metric: map[string]string{
 						cfg.Labels.ServiceName:      "frontend",
-						cfg.Labels.ServiceNamespace:  "otel-demo",
-						cfg.Labels.DeploymentEnv:     "production",
+						cfg.Labels.ServiceNamespace: "otel-demo",
+						cfg.Labels.DeploymentEnv:    "production",
 					},
 					Value: queries.NewPromValue(float64(now.Unix()), "42.5"),
 				},
@@ -206,9 +206,9 @@ func TestHandleServices(t *testing.T) {
 				{
 					Metric: map[string]string{
 						cfg.Labels.ServiceName:      "frontend",
-						cfg.Labels.ServiceNamespace:  "otel-demo",
-						cfg.Labels.SDKLanguage:       "go",
-						cfg.Labels.DeploymentEnv:     "production",
+						cfg.Labels.ServiceNamespace: "otel-demo",
+						cfg.Labels.SDKLanguage:      "go",
+						cfg.Labels.DeploymentEnv:    "production",
 					},
 					Value: queries.NewPromValue(float64(now.Unix()), "1"),
 				},
@@ -441,8 +441,8 @@ func TestResponseCache(t *testing.T) {
 				{
 					Metric: map[string]string{
 						cfg.Labels.ServiceName:      "cached-svc",
-						cfg.Labels.ServiceNamespace:  "ns",
-						cfg.Labels.DeploymentEnv:     "prod",
+						cfg.Labels.ServiceNamespace: "ns",
+						cfg.Labels.DeploymentEnv:    "prod",
 					},
 					Value: queries.NewPromValue(float64(now.Unix()), "5.0"),
 				},
@@ -451,9 +451,9 @@ func TestResponseCache(t *testing.T) {
 				{
 					Metric: map[string]string{
 						cfg.Labels.ServiceName:      "cached-svc",
-						cfg.Labels.ServiceNamespace:  "ns",
-						cfg.Labels.SDKLanguage:       "java",
-						cfg.Labels.DeploymentEnv:     "prod",
+						cfg.Labels.ServiceNamespace: "ns",
+						cfg.Labels.SDKLanguage:      "java",
+						cfg.Labels.DeploymentEnv:    "prod",
 					},
 					Value: queries.NewPromValue(float64(now.Unix()), "1"),
 				},
@@ -826,7 +826,7 @@ func TestServiceMapSpanmetricsFallback(t *testing.T) {
 				{
 					Metric: map[string]string{
 						cfg.Labels.ServerAddress: "target-db.team-b.svc.cluster.local:5432",
-						cfg.Labels.DBSystem:     "postgresql",
+						cfg.Labels.DBSystem:      "postgresql",
 					},
 					Value: queries.NewPromValue(float64(now.Unix()), "15"),
 				},
@@ -1045,4 +1045,204 @@ func TestServiceMapSpanmetricsFallback(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestIngressAliasQueryExpansion(t *testing.T) {
+	now := time.Now()
+	from := fmt.Sprintf("%d", now.Add(-1*time.Hour).Unix())
+	to := fmt.Sprintf("%d", now.Unix())
+	cfg := otelconfig.Default()
+
+	t.Run("connected endpoint includes alias hostnames in queries", func(t *testing.T) {
+		promSrv, captured := queryCapturingPromServer(t, map[string][]queries.PromResult{})
+		defer promSrv.Close()
+
+		app := newTestApp(t, promSrv.URL, defaultCaps())
+		app.settings.IngressAliases = map[string]string{
+			"myapp.intern.nav.no": "myservice",
+		}
+		app.ingressByService = map[string][]string{
+			"myservice": {"myapp.intern.nav.no"},
+		}
+
+		req := httptest.NewRequest(http.MethodGet,
+			"/services/team/myservice/connected?from="+from+"&to="+to, nil)
+		req.SetPathValue("namespace", "team")
+		req.SetPathValue("service", "myservice")
+		w := httptest.NewRecorder()
+		app.handleConnectedServices(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		foundServerAddr := false
+		foundHTTPHost := false
+		// PromQL escapes dots, so look for the escaped form
+		aliasPattern := `myapp\\.intern\\.nav\\.no`
+		for _, q := range *captured {
+			if strings.Contains(q, aliasPattern) {
+				if strings.Contains(q, cfg.Labels.ServerAddress) {
+					foundServerAddr = true
+				}
+				if strings.Contains(q, cfg.Labels.HTTPHost) {
+					foundHTTPHost = true
+				}
+			}
+		}
+		if !foundServerAddr {
+			t.Error("expected alias hostname in server_address query, not found")
+			for i, q := range *captured {
+				t.Logf("  query[%d]: %s", i, q)
+			}
+		}
+		if !foundHTTPHost {
+			t.Error("expected alias hostname in http_host query, not found")
+		}
+	})
+
+	t.Run("service map scoped queries include alias hostnames", func(t *testing.T) {
+		promSrv, captured := queryCapturingPromServer(t, map[string][]queries.PromResult{})
+		defer promSrv.Close()
+
+		app := newTestApp(t, promSrv.URL, defaultCaps())
+		app.settings.IngressAliases = map[string]string{
+			"myapp.intern.nav.no": "myservice",
+		}
+		app.ingressByService = map[string][]string{
+			"myservice": {"myapp.intern.nav.no"},
+		}
+
+		req := httptest.NewRequest(http.MethodGet,
+			"/service-map?service=myservice&from="+from+"&to="+to, nil)
+		w := httptest.NewRecorder()
+		app.handleServiceMap(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		found := false
+		for _, q := range *captured {
+			if strings.Contains(q, `myapp\\.intern\\.nav\\.no`) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected alias hostname in service map queries, not found")
+			for i, q := range *captured {
+				t.Logf("  query[%d]: %s", i, q)
+			}
+		}
+	})
+
+	t.Run("no alias queries when no aliases configured", func(t *testing.T) {
+		promSrv, captured := queryCapturingPromServer(t, map[string][]queries.PromResult{})
+		defer promSrv.Close()
+
+		app := newTestApp(t, promSrv.URL, defaultCaps())
+
+		req := httptest.NewRequest(http.MethodGet,
+			"/services/team/myservice/connected?from="+from+"&to="+to, nil)
+		req.SetPathValue("namespace", "team")
+		req.SetPathValue("service", "myservice")
+		w := httptest.NewRecorder()
+		app.handleConnectedServices(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+
+		for _, q := range *captured {
+			if strings.Contains(q, `intern\\.nav\\.no`) || strings.Contains(q, "intern.nav.no") {
+				t.Errorf("unexpected alias hostname in query without aliases configured: %s", q)
+			}
+		}
+	})
+}
+
+func TestResolveIngressAlias(t *testing.T) {
+	t.Run("resolves known alias", func(t *testing.T) {
+		app := &App{
+			settings: queries.PluginSettings{
+				IngressAliases: map[string]string{
+					"myapp.intern.nav.no": "myservice",
+				},
+			},
+		}
+		got := app.resolveIngressAlias("myapp.intern.nav.no")
+		if got != "myservice" {
+			t.Errorf("resolveIngressAlias(myapp.intern.nav.no) = %q, want %q", got, "myservice")
+		}
+	})
+
+	t.Run("returns original for unknown address", func(t *testing.T) {
+		app := &App{
+			settings: queries.PluginSettings{
+				IngressAliases: map[string]string{
+					"myapp.intern.nav.no": "myservice",
+				},
+			},
+		}
+		got := app.resolveIngressAlias("other.example.com")
+		if got != "other.example.com" {
+			t.Errorf("resolveIngressAlias(other.example.com) = %q, want %q", got, "other.example.com")
+		}
+	})
+
+	t.Run("returns original when no aliases configured", func(t *testing.T) {
+		app := &App{}
+		got := app.resolveIngressAlias("myapp.intern.nav.no")
+		if got != "myapp.intern.nav.no" {
+			t.Errorf("resolveIngressAlias = %q, want %q", got, "myapp.intern.nav.no")
+		}
+	})
+}
+
+func TestIngressAliasNormalization(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]string
+		wantKey string
+		wantSvc string
+	}{
+		{"lowercase", map[string]string{"MyApp.Intern.NAV.NO": "myservice"}, "myapp.intern.nav.no", "myservice"},
+		{"trailing dot", map[string]string{"myapp.intern.nav.no.": "myservice"}, "myapp.intern.nav.no", "myservice"},
+		{"port 443", map[string]string{"myapp.intern.nav.no:443": "myservice"}, "myapp.intern.nav.no", "myservice"},
+		{"port 80", map[string]string{"myapp.intern.nav.no:80": "myservice"}, "myapp.intern.nav.no", "myservice"},
+		{"non-standard port", map[string]string{"myapp.intern.nav.no:8443": "myservice"}, "myapp.intern.nav.no:8443", "myservice"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &App{
+				settings: queries.PluginSettings{IngressAliases: tc.input},
+			}
+			normalized := make(map[string]string, len(app.settings.IngressAliases))
+			app.ingressByService = make(map[string][]string)
+			for hostname, svcName := range app.settings.IngressAliases {
+				h := normalizeAddress(hostname)
+				normalized[h] = svcName
+				app.ingressByService[svcName] = append(app.ingressByService[svcName], h)
+			}
+			app.settings.IngressAliases = normalized
+
+			if svc, ok := app.settings.IngressAliases[tc.wantKey]; !ok {
+				t.Errorf("expected key %q in normalized aliases, got %v", tc.wantKey, app.settings.IngressAliases)
+			} else if svc != tc.wantSvc {
+				t.Errorf("alias[%q] = %q, want %q", tc.wantKey, svc, tc.wantSvc)
+			}
+
+			hostnames := app.ingressHostnames(tc.wantSvc)
+			if len(hostnames) == 0 {
+				t.Errorf("expected ingressHostnames(%q) to return hostnames", tc.wantSvc)
+			}
+
+			got := app.resolveIngressAlias(tc.wantKey)
+			if got != tc.wantSvc {
+				t.Errorf("resolveIngressAlias(%q) = %q, want %q", tc.wantKey, got, tc.wantSvc)
+			}
+		})
+	}
 }

--- a/pkg/plugin/queries/models.go
+++ b/pkg/plugin/queries/models.go
@@ -63,6 +63,12 @@ type PluginSettings struct {
 
 	// LabelOverrides allows customising Prometheus label names for non-standard OTel pipelines.
 	LabelOverrides LabelOverrides `json:"labelOverrides,omitempty"`
+
+	// IngressAliases maps ingress hostnames to the service_name they route to.
+	// This allows the plugin to discover callers that reach a service via its
+	// ingress hostname (e.g., on-prem services calling via nais ingress).
+	// Key: hostname (e.g., "tilgangsmaskin.intern.nav.no"), Value: service_name.
+	IngressAliases map[string]string `json:"ingressAliases,omitempty"`
 }
 
 // Capabilities represents the detected OTel data capabilities.

--- a/pkg/plugin/servicemap.go
+++ b/pkg/plugin/servicemap.go
@@ -583,7 +583,7 @@ func (a *App) querySpanmetricsTopologyBatch(
 			if svc == "" || addr == "" {
 				continue
 			}
-			serverName := extractTopologyNodeName(addr)
+			serverName := a.resolveIngressAlias(extractTopologyNodeName(addr))
 			if serverName == "" || serverName == svc {
 				continue
 			}
@@ -605,7 +605,7 @@ func (a *App) querySpanmetricsTopologyBatch(
 		if caller == "" || addr == "" {
 			continue
 		}
-		serverName := extractTopologyNodeName(addr)
+		serverName := a.resolveIngressAlias(extractTopologyNodeName(addr))
 		if serverName == "" || serverName == caller {
 			continue
 		}
@@ -1049,6 +1049,25 @@ func (a *App) querySpanmetricsTopologyFallback(
 			cfg.Labels.HTTPHost, escapedSvc,
 			cfg.Labels.StatusCode, cfg.StatusCodes.Error, envFilter, rangeStr,
 		)
+
+		// Ingress alias supplement: also find callers via configured ingress hostnames.
+		for _, hostname := range a.ingressHostnames(service) {
+			escapedHost := promQLEscape(hostname)
+			inRateQ += fmt.Sprintf(
+				` or sum by (%s, %s) (rate(%s{%s="%s", %s=~"%s(:[0-9]+)?"%s}%s))`,
+				cfg.Labels.ServiceName, cfg.Labels.ServiceNamespace,
+				callsMetric, cfg.Labels.SpanKind, cfg.SpanKinds.Client,
+				cfg.Labels.ServerAddress, escapedHost, envFilter, rangeStr,
+			)
+			inErrQ += fmt.Sprintf(
+				` or sum by (%s, %s) (rate(%s{%s="%s", %s=~"%s(:[0-9]+)?", %s="%s"%s}%s))`,
+				cfg.Labels.ServiceName, cfg.Labels.ServiceNamespace,
+				callsMetric, cfg.Labels.SpanKind, cfg.SpanKinds.Client,
+				cfg.Labels.ServerAddress, escapedHost,
+				cfg.Labels.StatusCode, cfg.StatusCodes.Error, envFilter, rangeStr,
+			)
+		}
+
 		jobs = append(jobs,
 			QueryJob{"smInRate", inRateQ},
 			QueryJob{"smInRateHost", inRateHostQ},
@@ -1085,7 +1104,7 @@ func (a *App) querySpanmetricsTopologyFallback(
 			if addr == "" {
 				continue
 			}
-			serverName := extractTopologyNodeName(addr)
+			serverName := a.resolveIngressAlias(extractTopologyNodeName(addr))
 			if serverName == "" || serverName == service {
 				continue
 			}
@@ -1111,7 +1130,7 @@ func (a *App) querySpanmetricsTopologyFallback(
 			if addr == "" {
 				continue
 			}
-			serverName := extractTopologyNodeName(addr)
+			serverName := a.resolveIngressAlias(extractTopologyNodeName(addr))
 			if serverName == "" || serverName == service {
 				continue
 			}
@@ -1183,6 +1202,19 @@ func extractTopologyNodeName(addr string) string {
 
 	// External hostnames: normalize (strip standard ports)
 	return normalizeAddress(addr)
+}
+
+// resolveIngressAlias checks if the given address is a known ingress alias
+// and returns the mapped service name if so. Otherwise returns the original name.
+func (a *App) resolveIngressAlias(name string) string {
+	if a.settings.IngressAliases == nil {
+		return name
+	}
+	// Try the name as-is (e.g., "tilgangsmaskin.intern.nav.no")
+	if svc, ok := a.settings.IngressAliases[name]; ok {
+		return svc
+	}
+	return name
 }
 
 func (a *App) queryServiceMap( //nolint:gocyclo // complex due to filtering + node/edge assembly

--- a/pkg/plugin/servicemap.go
+++ b/pkg/plugin/servicemap.go
@@ -1059,11 +1059,24 @@ func (a *App) querySpanmetricsTopologyFallback(
 				callsMetric, cfg.Labels.SpanKind, cfg.SpanKinds.Client,
 				cfg.Labels.ServerAddress, escapedHost, envFilter, rangeStr,
 			)
+			inRateHostQ += fmt.Sprintf(
+				` or sum by (%s, %s) (rate(%s{%s="%s", %s=~"%s(:[0-9]+)?"%s}%s))`,
+				cfg.Labels.ServiceName, cfg.Labels.ServiceNamespace,
+				callsMetric, cfg.Labels.SpanKind, cfg.SpanKinds.Client,
+				cfg.Labels.HTTPHost, escapedHost, envFilter, rangeStr,
+			)
 			inErrQ += fmt.Sprintf(
 				` or sum by (%s, %s) (rate(%s{%s="%s", %s=~"%s(:[0-9]+)?", %s="%s"%s}%s))`,
 				cfg.Labels.ServiceName, cfg.Labels.ServiceNamespace,
 				callsMetric, cfg.Labels.SpanKind, cfg.SpanKinds.Client,
 				cfg.Labels.ServerAddress, escapedHost,
+				cfg.Labels.StatusCode, cfg.StatusCodes.Error, envFilter, rangeStr,
+			)
+			inErrHostQ += fmt.Sprintf(
+				` or sum by (%s, %s) (rate(%s{%s="%s", %s=~"%s(:[0-9]+)?", %s="%s"%s}%s))`,
+				cfg.Labels.ServiceName, cfg.Labels.ServiceNamespace,
+				callsMetric, cfg.Labels.SpanKind, cfg.SpanKinds.Client,
+				cfg.Labels.HTTPHost, escapedHost,
 				cfg.Labels.StatusCode, cfg.StatusCodes.Error, envFilter, rangeStr,
 			)
 		}

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -259,11 +259,15 @@ const AppConfig = ({ plugin }: AppConfigProps) => {
       }
     }
 
-    // Build ingress alias map from rows
+    // Build ingress alias map from rows, normalizing hostnames to match backend behavior.
     const ingressAliases: Record<string, string> = {};
     for (const alias of state.ingressAliases) {
       if (alias.hostname && alias.service) {
-        ingressAliases[alias.hostname] = alias.service;
+        const normalized = alias.hostname
+          .toLowerCase()
+          .replace(/\.$/, '')
+          .replace(/:(443|80)$/, '');
+        ingressAliases[normalized] = alias.service;
       }
     }
 

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -21,6 +21,11 @@ interface EnvOverride {
   lokiUid: string;
 }
 
+type IngressAlias = {
+  hostname: string;
+  service: string;
+};
+
 type State = {
   metricsUid: string;
   tracesUid: string;
@@ -29,6 +34,7 @@ type State = {
   durationUnit: string;
   labelOverrides: LabelOverrides;
   envOverrides: EnvOverride[];
+  ingressAliases: IngressAlias[];
   serviceAccountToken: string;
   tokenConfigured: boolean;
 };
@@ -59,6 +65,10 @@ const AppConfig = ({ plugin }: AppConfigProps) => {
     durationUnit: jsonData?.durationUnit || '',
     labelOverrides: jsonData?.labelOverrides ?? {},
     envOverrides: parseEnvOverrides(jsonData?.tracesDataSource, jsonData?.logsDataSource),
+    ingressAliases: Object.entries(jsonData?.ingressAliases ?? {}).map(([hostname, service]) => ({
+      hostname,
+      service,
+    })),
     serviceAccountToken: '',
     tokenConfigured: secureJsonFields?.serviceAccountToken === true,
   });
@@ -212,6 +222,28 @@ const AppConfig = ({ plugin }: AppConfigProps) => {
     }));
   };
 
+  const onAliasChange = (idx: number, field: keyof IngressAlias) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setState((prev) => {
+      const aliases = [...prev.ingressAliases];
+      aliases[idx] = { ...aliases[idx], [field]: e.target.value.trim() };
+      return { ...prev, ingressAliases: aliases };
+    });
+  };
+
+  const addAlias = () => {
+    setState((prev) => ({
+      ...prev,
+      ingressAliases: [...prev.ingressAliases, { hostname: '', service: '' }],
+    }));
+  };
+
+  const removeAlias = (idx: number) => {
+    setState((prev) => ({
+      ...prev,
+      ingressAliases: prev.ingressAliases.filter((_, i) => i !== idx),
+    }));
+  };
+
   const onSubmit = () => {
     // Build byEnvironment maps from overrides
     const tracesByEnv: Record<string, DsRef> = {};
@@ -224,6 +256,14 @@ const AppConfig = ({ plugin }: AppConfigProps) => {
         if (ov.lokiUid) {
           logsByEnv[ov.env] = { uid: ov.lokiUid, type: 'loki' };
         }
+      }
+    }
+
+    // Build ingress alias map from rows
+    const ingressAliases: Record<string, string> = {};
+    for (const alias of state.ingressAliases) {
+      if (alias.hostname && alias.service) {
+        ingressAliases[alias.hostname] = alias.service;
       }
     }
 
@@ -245,6 +285,7 @@ const AppConfig = ({ plugin }: AppConfigProps) => {
         metricNamespace: state.metricNamespace || undefined,
         durationUnit: state.durationUnit || undefined,
         labelOverrides: Object.values(state.labelOverrides).some(Boolean) ? state.labelOverrides : undefined,
+        ingressAliases: Object.keys(ingressAliases).length > 0 ? ingressAliases : undefined,
       },
       secureJsonData: state.serviceAccountToken ? { serviceAccountToken: state.serviceAccountToken } : undefined,
     } as any);
@@ -599,6 +640,37 @@ const AppConfig = ({ plugin }: AppConfigProps) => {
             onChange={onLabelOverrideChange('deploymentEnvLabel')}
           />
         </Field>
+      </FieldSet>
+
+      <FieldSet label="Ingress Aliases" className={s.marginTop}>
+        <p className={s.description}>
+          Map ingress hostnames to service names so on-prem callers that reach services via nais ingress become visible
+          in the caller list and service map.
+        </p>
+        {state.ingressAliases.map((alias, idx) => (
+          <div key={idx} className={s.envRow}>
+            <Field label={idx === 0 ? 'Ingress Hostname' : undefined}>
+              <Input
+                width={40}
+                value={alias.hostname}
+                placeholder="tilgangsmaskin.intern.nav.no"
+                onChange={onAliasChange(idx, 'hostname')}
+              />
+            </Field>
+            <Field label={idx === 0 ? 'Service Name' : undefined}>
+              <Input
+                width={30}
+                value={alias.service}
+                placeholder="populasjonstilgangskontroll"
+                onChange={onAliasChange(idx, 'service')}
+              />
+            </Field>
+            <IconButton name="trash-alt" tooltip="Remove alias" onClick={() => removeAlias(idx)} />
+          </div>
+        ))}
+        <Button variant="secondary" icon="plus" size="sm" onClick={addAlias} type="button">
+          Add alias
+        </Button>
       </FieldSet>
 
       <div className={s.marginTop}>

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -31,4 +31,6 @@ export interface AppPluginSettings {
   metricNamespace?: string;
   durationUnit?: string;
   labelOverrides?: LabelOverrides;
+  /** Ingress hostname → service name mapping for discovering on-prem callers via nais ingress. */
+  ingressAliases?: Record<string, string>;
 }


### PR DESCRIPTION
## Summary

Adds configurable ingress hostname → service name mapping so that on-prem (FSS) callers reaching GCP services via nais ingress become visible in caller lists and service maps.

### Problem

On-prem services (e.g., oppgave, saf) call GCP apps through nais ingress hostnames like `tilgangsmaskin.intern.nav.no`. The plugin discovers callers via CLIENT spans where `server_address=~"service_name[.:].*"`, but the ingress hostname does not match the service name (`populasjonstilgangskontroll`), hiding ~44% of caller traffic.

### Solution

- **Plugin settings**: New `ingressAliases` map (`hostname → service_name`) in jsonData
- **Backend**: Builds a reverse lookup (`service → []hostnames`) at startup. Expands inbound caller queries in `connected.go` and `servicemap.go` with additional PromQL `or` clauses for each alias. Resolves aliases in outbound topology node names.
- **Frontend**: Key-value editor in AppConfig for managing aliases

### Files changed

| File | Change |
|------|--------|
| `pkg/plugin/queries/models.go` | `IngressAliases` field on `PluginSettings` |
| `pkg/plugin/app.go` | Reverse lookup + helper methods |
| `pkg/plugin/connected.go` | Inbound query expansion + outbound alias resolution |
| `pkg/plugin/servicemap.go` | BFS query expansion + topology alias resolution |
| `src/types/plugin.ts` | `ingressAliases` type |
| `src/components/AppConfig/AppConfig.tsx` | Alias editor UI |
| `CHANGELOG.md` | Unreleased entry |

### Future work

Phase 2: auto-populate aliases from the nais GraphQL API (`console.nav.cloud.nais.io/graphql`) so manual configuration is not needed.