### PR TITLE
ci: anchor release-please to the existing v* tag scheme

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "node",
       "package-name": "nais-apm-app",
+      "component": "",
       "include-v-in-tag": true,
       "bump-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
**Fixes the release-please Release PR proposing `0.21.0` instead of `0.20.2`.**

release-please was deriving a tag *component* from `package-name` (`nais-apm-app`), so it looked for a `nais-apm-app-v0.20.1` tag to anchor the last release. The real tags are plain `v0.20.1` — so it never found the boundary, re-scanned history from before `v0.20.1`, re-counted already-released `feat`s into a spurious **minor** bump (`0.21.0`), included already-shipped fixes in the changelog, and would have cut an off-convention `nais-apm-app-v*` tag.

Setting `"component": ""` makes tags plain `v<version>`, matching the existing `v0.20.0`/`v0.20.1`. release-please then anchors to `v0.20.1` and proposes the correct **`0.20.2`** — the single `fix(config)` (#92) landed since — under Bug Fixes.

After merge, release-please will supersede #96 with a corrected Release PR (`v0.20.2`, plain `v*` tag).