### PR TITLE
ci: anchor release-please to release-please-owned nais-apm-app-v* tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
     ".": {
       "release-type": "node",
       "package-name": "nais-apm-app",
-      "component": "",
       "include-v-in-tag": true,
       "bump-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
Follow-up to #97. The `component: ""` approach couldn't anchor to the pre-existing plain `v*` tags — release-please logged `Found release tag with component '', but not configured in manifest` and produced no corrected Release PR (those `v*` tags were cut by the old manual flow, not by release-please, so it can't map them to the root package).

**Fix:** revert to the package-name-derived component (same style as the SDK's `apm-v*`) and backfill a `nais-apm-app-v0.20.1` anchor tag (→ the v0.20.1 commit, already pushed). release-please now finds that tag, anchors to it, and proposes the correct **`0.20.2`** (the single `fix(config)` #92 since), self-sustaining from here.

Tag scheme going forward: `nais-apm-app-v<version>` (historical `v0.20.1`/`v0.20.0` stay as-is). After merge, release-please updates #96 to `0.20.2`.