### PR TITLE
feat(frontend): detect minified stacks + source-map doctor (#60)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -198,6 +198,34 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/LogPatternsResponse" }
 
+  /services/{namespace}/{service}/sourcemap-doctor:
+    get:
+      tags: [experimental]
+      summary: Diagnose why a minified frontend stack's source map wasn't resolved.
+      description: >
+        Pure diagnostics for issue #60. Server-side, the plugin fetches the given
+        bundle from the allowlisted frontend CDN (cdn.nav.no only — SSRF guard),
+        then reports whether the bundle is reachable, advertises a
+        `//# sourceMappingURL=` comment, and whether the referenced `.map` is
+        fetchable. The plugin never resolves/symbolicates the stack itself; the
+        actual fix is an Alloy faro.receiver ingest-config change.
+      parameters:
+        - { $ref: "#/components/parameters/namespacePath" }
+        - { $ref: "#/components/parameters/servicePath" }
+        - name: url
+          in: query
+          required: true
+          schema: { type: string }
+          description: Absolute http(s) URL of the frame's JS bundle on cdn.nav.no.
+      responses:
+        "200":
+          description: Source-map diagnosis checklist.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SourcemapDoctorResult" }
+        "400":
+          description: Missing url, or url is not an absolute http(s) URL on cdn.nav.no.
+
   /services/{namespace}/{service}/traces/breakdown:
     get:
       tags: [experimental]
@@ -1123,6 +1151,22 @@ components:
               isNew: { type: boolean }
               filterLiteral: { type: string }
         note: { type: string }
+    SourcemapDoctorResult:
+      type: object
+      properties:
+        url: { type: string }
+        ok:
+          type: boolean
+          description: True when the bundle's source map is present and fetchable.
+        sourceMapUrl: { type: string }
+        checks:
+          type: array
+          items:
+            type: object
+            properties:
+              name: { type: string, enum: [script-fetchable, sourcemap-comment, sourcemap-fetchable] }
+              status: { type: string, enum: [pass, fail, skip] }
+              detail: { type: string }
     TraceBreakdownResponse:
       type: object
       properties:

--- a/pkg/plugin/app.go
+++ b/pkg/plugin/app.go
@@ -386,6 +386,7 @@ func (a *App) routes() []appRoute {
 		{"/services/{namespace}/{service}/frontend/versions", a.handleFrontendVersions},
 		{"/services/{namespace}/{service}/frontend/sessions", a.handleFrontendSessions},
 		{"/services/{namespace}/{service}/logs/patterns", a.handleLogPatterns},
+		{"/services/{namespace}/{service}/sourcemap-doctor", a.handleSourcemapDoctor},
 		{"/services/{namespace}/{service}/traces/breakdown", a.handleTraceBreakdown},
 		{"/services/{namespace}/{service}/feedback", a.handleFeedback},
 		{"/services/{namespace}/{service}/exceptions/groups", a.handleExceptionGroups},

--- a/pkg/plugin/sourcemapdoctor.go
+++ b/pkg/plugin/sourcemapdoctor.go
@@ -1,0 +1,201 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// Source-map doctor (#60).
+//
+// Frontend-stack deobfuscation happens server-side at ingest: Alloy's
+// faro.receiver resolves the `.map` and writes the resolved stack to Loki. When
+// a stored stack is still minified, the resolution didn't happen — this handler
+// helps explain *why* by probing the offending bundle. It is pure diagnostics:
+// it NEVER resolves or symbolicates a stack itself (an explicit non-goal), and
+// the actual ingest fix is a cross-repo Alloy config change owned by the
+// platform team.
+//
+// SSRF guard: this is the one handler that makes an outbound request to a
+// URL supplied by the caller, so the target host is allowlisted to cdn.nav.no
+// (the public frontend-asset CDN). The initial URL, the resolved `.map` URL,
+// and every redirect hop are all validated against the allowlist before a
+// request is issued.
+
+// sourcemapCDNHost is the only host the doctor will fetch from.
+const sourcemapCDNHost = "cdn.nav.no"
+
+// maxSourcemapBytes caps how much of a bundle/map we read. Bundles are large,
+// but the sourceMappingURL comment lives near the end; we read up to this cap
+// and scan for it.
+const maxSourcemapBytes = 24 << 20 // 24 MiB
+
+// sourceMappingRe matches a `//# sourceMappingURL=<ref>` (or the legacy `//@`)
+// annotation. The reference may be a relative path, an absolute URL, or an
+// inline `data:` URI.
+var sourceMappingRe = regexp.MustCompile(`//[#@]\s*sourceMappingURL=(\S+)`)
+
+// SourcemapCheck is one pass/fail step in the diagnosis.
+type SourcemapCheck struct {
+	Name   string `json:"name"`
+	Status string `json:"status"` // "pass" | "fail" | "skip"
+	Detail string `json:"detail,omitempty"`
+}
+
+// SourcemapDoctorResult is the /sourcemap-doctor payload.
+type SourcemapDoctorResult struct {
+	URL          string           `json:"url"`
+	OK           bool             `json:"ok"`
+	Checks       []SourcemapCheck `json:"checks"`
+	SourceMapURL string           `json:"sourceMapUrl,omitempty"`
+}
+
+// sourcemapHostAllowed reports whether host (optionally with a port) is the
+// allowlisted frontend-asset CDN. Case-insensitive; the bare port is ignored.
+func sourcemapHostAllowed(host string) bool {
+	h := strings.ToLower(host)
+	if i := strings.IndexByte(h, ':'); i >= 0 {
+		h = h[:i]
+	}
+	return h == sourcemapCDNHost
+}
+
+// handleSourcemapDoctor probes a minified frame's bundle and returns a pass/fail
+// checklist explaining whether its source map is resolvable.
+// GET /services/{namespace}/{service}/sourcemap-doctor?url=<frameJsUrl>
+func (a *App) handleSourcemapDoctor(w http.ResponseWriter, req *http.Request) {
+	if !requireGET(w, req) {
+		return
+	}
+	_, service := parseServiceRef(req)
+	if !requireServiceParam(w, service) {
+		return
+	}
+
+	raw := strings.TrimSpace(req.URL.Query().Get("url"))
+	if raw == "" {
+		http.Error(w, `{"error":"missing url query parameter"}`, http.StatusBadRequest)
+		return
+	}
+	u, err := url.Parse(raw)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || !sourcemapHostAllowed(u.Host) {
+		// SSRF guard: only absolute http(s) URLs on the allowlisted CDN.
+		http.Error(w, fmt.Sprintf(`{"error":"url must be an absolute http(s) URL on %s"}`, sourcemapCDNHost), http.StatusBadRequest)
+		return
+	}
+
+	// Reuse the shared outbound client's transport/timeout, but add a
+	// redirect guard so a 30x can't bounce the request off the allowlist.
+	client := &http.Client{
+		Timeout:   a.healthClient.Timeout,
+		Transport: a.healthClient.Transport,
+		CheckRedirect: func(r *http.Request, via []*http.Request) error {
+			if !sourcemapHostAllowed(r.URL.Host) {
+				return fmt.Errorf("redirect to disallowed host %q blocked", r.URL.Host)
+			}
+			if len(via) >= 5 {
+				return fmt.Errorf("stopped after 5 redirects")
+			}
+			return nil
+		},
+	}
+
+	res := diagnoseSourcemap(req.Context(), client, u, sourcemapHostAllowed)
+	writeJSON(w, res)
+}
+
+// diagnoseSourcemap runs the pass/fail checklist against a bundle URL. It is
+// split from the handler so tests can drive it against an httptest server: the
+// handler enforces the host allowlist up front, and allowHost re-validates the
+// resolved `.map` URL host here (a relative map resolves to the same allowlisted
+// host; an absolute cross-host map is refused rather than fetched).
+func diagnoseSourcemap(ctx context.Context, client *http.Client, jsURL *url.URL, allowHost func(string) bool) SourcemapDoctorResult {
+	res := SourcemapDoctorResult{URL: jsURL.String()}
+
+	// Check 1: the bundle itself is fetchable.
+	body, status, err := fetchLimited(ctx, client, jsURL.String(), maxSourcemapBytes)
+	if err != nil {
+		res.Checks = append(res.Checks, SourcemapCheck{Name: "script-fetchable", Status: "fail", Detail: "could not fetch bundle: " + err.Error()})
+		return res
+	}
+	if status != http.StatusOK {
+		res.Checks = append(res.Checks, SourcemapCheck{Name: "script-fetchable", Status: "fail", Detail: fmt.Sprintf("bundle returned HTTP %d", status)})
+		return res
+	}
+	res.Checks = append(res.Checks, SourcemapCheck{Name: "script-fetchable", Status: "pass", Detail: "HTTP 200"})
+
+	// Check 2: the bundle advertises a source map.
+	ref := extractSourceMappingURL(body)
+	if ref == "" {
+		res.Checks = append(res.Checks, SourcemapCheck{Name: "sourcemap-comment", Status: "fail", Detail: "no //# sourceMappingURL= comment — the build did not emit a source-map reference"})
+		return res
+	}
+
+	// An inline data: URI carries the whole map; nothing to fetch.
+	if strings.HasPrefix(ref, "data:") {
+		res.SourceMapURL = "(inline data URI)"
+		res.Checks = append(res.Checks, SourcemapCheck{Name: "sourcemap-comment", Status: "pass", Detail: "inline source map (data URI)"})
+		res.Checks = append(res.Checks, SourcemapCheck{Name: "sourcemap-fetchable", Status: "pass", Detail: "inline — no separate fetch needed"})
+		res.OK = true
+		return res
+	}
+	res.Checks = append(res.Checks, SourcemapCheck{Name: "sourcemap-comment", Status: "pass", Detail: "references " + ref})
+
+	// Check 3: the referenced .map is fetchable.
+	mapURL, err := jsURL.Parse(ref)
+	if err != nil {
+		res.Checks = append(res.Checks, SourcemapCheck{Name: "sourcemap-fetchable", Status: "fail", Detail: "unparseable sourceMappingURL: " + err.Error()})
+		return res
+	}
+	res.SourceMapURL = mapURL.String()
+	if !allowHost(mapURL.Host) {
+		res.Checks = append(res.Checks, SourcemapCheck{Name: "sourcemap-fetchable", Status: "fail", Detail: "source map points off-CDN (" + mapURL.Host + ") — not fetched"})
+		return res
+	}
+	_, mapStatus, err := fetchLimited(ctx, client, mapURL.String(), maxSourcemapBytes)
+	if err != nil {
+		res.Checks = append(res.Checks, SourcemapCheck{Name: "sourcemap-fetchable", Status: "fail", Detail: "could not fetch .map: " + err.Error()})
+		return res
+	}
+	if mapStatus != http.StatusOK {
+		res.Checks = append(res.Checks, SourcemapCheck{Name: "sourcemap-fetchable", Status: "fail", Detail: fmt.Sprintf(".map returned HTTP %d — it isn't published alongside the bundle", mapStatus)})
+		return res
+	}
+	res.Checks = append(res.Checks, SourcemapCheck{Name: "sourcemap-fetchable", Status: "pass", Detail: "HTTP 200"})
+	res.OK = true
+	return res
+}
+
+// extractSourceMappingURL returns the reference from the last sourceMappingURL
+// annotation in body (the meaningful one is emitted at the end of a bundle), or
+// "" if none is present.
+func extractSourceMappingURL(body []byte) string {
+	matches := sourceMappingRe.FindAllSubmatch(body, -1)
+	if len(matches) == 0 {
+		return ""
+	}
+	return string(matches[len(matches)-1][1])
+}
+
+// fetchLimited GETs rawURL and returns up to limit bytes of the body plus the
+// HTTP status. The body is always capped to bound memory on large bundles.
+func fetchLimited(ctx context.Context, client *http.Client, rawURL string, limit int64) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(io.LimitReader(resp.Body, limit))
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return body, resp.StatusCode, nil
+}

--- a/pkg/plugin/sourcemapdoctor.go
+++ b/pkg/plugin/sourcemapdoctor.go
@@ -88,6 +88,20 @@ func (a *App) handleSourcemapDoctor(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// SSRF guard (primary): don't fetch the caller's parsed URL — rebuild a
+	// fresh URL whose authority is the hardcoded CDN constant, carrying over
+	// only the caller's path/query. After the sourcemapHostAllowed() check
+	// above the host can only be cdn.nav.no, so this changes no behaviour; it
+	// makes the fetched host *guaranteed constant* rather than merely checked,
+	// which also breaks the taint flow static analysis follows from the query
+	// parameter into the HTTP client.
+	safeURL := &url.URL{
+		Scheme:   "https",
+		Host:     sourcemapCDNHost,
+		Path:     u.Path,
+		RawQuery: u.RawQuery,
+	}
+
 	// Reuse the shared outbound client's transport/timeout, but add a
 	// redirect guard so a 30x can't bounce the request off the allowlist.
 	client := &http.Client{
@@ -104,7 +118,7 @@ func (a *App) handleSourcemapDoctor(w http.ResponseWriter, req *http.Request) {
 		},
 	}
 
-	res := diagnoseSourcemap(req.Context(), client, u, sourcemapHostAllowed)
+	res := diagnoseSourcemap(req.Context(), client, safeURL, sourcemapHostAllowed)
 	writeJSON(w, res)
 }
 
@@ -156,7 +170,11 @@ func diagnoseSourcemap(ctx context.Context, client *http.Client, jsURL *url.URL,
 		res.Checks = append(res.Checks, SourcemapCheck{Name: "sourcemap-fetchable", Status: "fail", Detail: "source map points off-CDN (" + mapURL.Host + ") — not fetched"})
 		return res
 	}
-	_, mapStatus, err := fetchLimited(ctx, client, mapURL.String(), maxSourcemapBytes)
+	// SSRF guard: rebuild the fetched map URL against the bundle's already
+	// validated authority (constant in production) rather than trusting the
+	// scheme/host embedded in the sourceMappingURL comment string.
+	fetchMapURL := &url.URL{Scheme: jsURL.Scheme, Host: jsURL.Host, Path: mapURL.Path, RawQuery: mapURL.RawQuery}
+	_, mapStatus, err := fetchLimited(ctx, client, fetchMapURL.String(), maxSourcemapBytes)
 	if err != nil {
 		res.Checks = append(res.Checks, SourcemapCheck{Name: "sourcemap-fetchable", Status: "fail", Detail: "could not fetch .map: " + err.Error()})
 		return res

--- a/pkg/plugin/sourcemapdoctor_test.go
+++ b/pkg/plugin/sourcemapdoctor_test.go
@@ -1,0 +1,168 @@
+package plugin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// allowAny is a permissive host predicate for the fetch-logic tests, which run
+// against an httptest server whose host is not the production CDN.
+func allowAny(string) bool { return true }
+
+func checkByName(t *testing.T, res SourcemapDoctorResult, name string) SourcemapCheck {
+	t.Helper()
+	for _, c := range res.Checks {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("no check named %q in %+v", name, res.Checks)
+	return SourcemapCheck{}
+}
+
+func newSourcemapTestServer() *httptest.Server {
+	mux := http.NewServeMux()
+	// Bundle that references a published .map — the healthy case.
+	mux.HandleFunc("/app.js", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("console.log(1)\n//# sourceMappingURL=app.js.map\n"))
+	})
+	mux.HandleFunc("/app.js.map", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"version":3}`))
+	})
+	// Bundle with no sourceMappingURL comment.
+	mux.HandleFunc("/nocomment.js", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("console.log(1)\n"))
+	})
+	// Bundle whose referenced .map is missing.
+	mux.HandleFunc("/badmap.js", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("console.log(1)\n//# sourceMappingURL=badmap.js.map\n"))
+	})
+	mux.HandleFunc("/badmap.js.map", func(w http.ResponseWriter, _ *http.Request) {
+		http.NotFound(w, nil)
+	})
+	// /gone.js is intentionally unregistered → 404.
+	return httptest.NewServer(mux)
+}
+
+func TestDiagnoseSourcemap_MapPresentPasses(t *testing.T) {
+	srv := newSourcemapTestServer()
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL + "/app.js")
+	res := diagnoseSourcemap(context.Background(), srv.Client(), u, allowAny)
+
+	if !res.OK {
+		t.Fatalf("expected ok=true, got %+v", res)
+	}
+	for _, name := range []string{"script-fetchable", "sourcemap-comment", "sourcemap-fetchable"} {
+		if c := checkByName(t, res, name); c.Status != "pass" {
+			t.Errorf("check %q: want pass, got %q (%s)", name, c.Status, c.Detail)
+		}
+	}
+	if res.SourceMapURL != srv.URL+"/app.js.map" {
+		t.Errorf("sourceMapUrl = %q, want %q", res.SourceMapURL, srv.URL+"/app.js.map")
+	}
+}
+
+func TestDiagnoseSourcemap_ScriptNotFoundFails(t *testing.T) {
+	srv := newSourcemapTestServer()
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL + "/gone.js")
+	res := diagnoseSourcemap(context.Background(), srv.Client(), u, allowAny)
+
+	if res.OK {
+		t.Fatalf("expected ok=false for a 404 bundle, got %+v", res)
+	}
+	if c := checkByName(t, res, "script-fetchable"); c.Status != "fail" {
+		t.Errorf("script-fetchable: want fail, got %q", c.Status)
+	}
+}
+
+func TestDiagnoseSourcemap_MissingSourceMappingURLFails(t *testing.T) {
+	srv := newSourcemapTestServer()
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL + "/nocomment.js")
+	res := diagnoseSourcemap(context.Background(), srv.Client(), u, allowAny)
+
+	if res.OK {
+		t.Fatalf("expected ok=false with no sourceMappingURL, got %+v", res)
+	}
+	if c := checkByName(t, res, "script-fetchable"); c.Status != "pass" {
+		t.Errorf("script-fetchable: want pass, got %q", c.Status)
+	}
+	if c := checkByName(t, res, "sourcemap-comment"); c.Status != "fail" {
+		t.Errorf("sourcemap-comment: want fail, got %q", c.Status)
+	}
+}
+
+func TestDiagnoseSourcemap_UnfetchableMapFails(t *testing.T) {
+	srv := newSourcemapTestServer()
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL + "/badmap.js")
+	res := diagnoseSourcemap(context.Background(), srv.Client(), u, allowAny)
+
+	if res.OK {
+		t.Fatalf("expected ok=false when .map is 404, got %+v", res)
+	}
+	if c := checkByName(t, res, "sourcemap-comment"); c.Status != "pass" {
+		t.Errorf("sourcemap-comment: want pass, got %q", c.Status)
+	}
+	if c := checkByName(t, res, "sourcemap-fetchable"); c.Status != "fail" {
+		t.Errorf("sourcemap-fetchable: want fail, got %q", c.Status)
+	}
+}
+
+func TestSourcemapHostAllowed(t *testing.T) {
+	cases := map[string]bool{
+		"cdn.nav.no":          true,
+		"CDN.NAV.NO":          true,
+		"cdn.nav.no:443":      true,
+		"evil.example.com":    false,
+		"cdn.nav.no.evil.com": false,
+		"localhost:8080":      false,
+		"cdn.nav.no.":         false, // trailing-dot FQDN is not the exact host
+		"internal.nais.local": false,
+	}
+	for host, want := range cases {
+		if got := sourcemapHostAllowed(host); got != want {
+			t.Errorf("sourcemapHostAllowed(%q) = %v, want %v", host, got, want)
+		}
+	}
+}
+
+func TestHandleSourcemapDoctor_RejectsNonCDNHost(t *testing.T) {
+	app := &App{healthClient: &http.Client{Timeout: 5 * time.Second}}
+
+	req := httptest.NewRequest(http.MethodGet, "/services/ns/svc/sourcemap-doctor?url=http://evil.example.com/app.js", nil)
+	req.SetPathValue("namespace", "ns")
+	req.SetPathValue("service", "svc")
+	rec := httptest.NewRecorder()
+
+	app.handleSourcemapDoctor(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (off-CDN host must be rejected before any fetch)", rec.Code)
+	}
+}
+
+func TestHandleSourcemapDoctor_RejectsMissingURL(t *testing.T) {
+	app := &App{healthClient: &http.Client{Timeout: 5 * time.Second}}
+
+	req := httptest.NewRequest(http.MethodGet, "/services/ns/svc/sourcemap-doctor", nil)
+	req.SetPathValue("namespace", "ns")
+	req.SetPathValue("service", "svc")
+	rec := httptest.NewRecorder()
+
+	app.handleSourcemapDoctor(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for missing url", rec.Code)
+	}
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1250,6 +1250,47 @@ export interface FeedbackResponse {
   unavailable?: boolean;
 }
 
+// ---- Source-map doctor (#60) ----
+
+export type SourcemapCheckStatus = 'pass' | 'fail' | 'skip';
+
+/** One pass/fail step in the source-map diagnosis. */
+export interface SourcemapCheck {
+  name: string;
+  status: SourcemapCheckStatus;
+  detail?: string;
+}
+
+/**
+ * Result of the server-side source-map "doctor": whether the referenced bundle
+ * advertises a source map and whether that map is fetchable. This is pure
+ * diagnostics — the plugin never resolves/symbolicates the stack itself
+ * (that happens at ingest in Alloy's faro.receiver).
+ */
+export interface SourcemapDoctorResult {
+  url: string;
+  ok: boolean;
+  checks: SourcemapCheck[];
+  sourceMapUrl?: string;
+}
+
+/**
+ * Diagnose why a minified frame's source map wasn't resolved. The backend
+ * fetches the bundle from cdn.nav.no (host-allowlisted, server-side) and
+ * reports a pass/fail checklist. `frameUrl` must be an absolute cdn.nav.no
+ * script URL (see frames.firstScriptUrl).
+ */
+export async function getSourcemapDoctor(
+  namespace: string,
+  service: string,
+  frameUrl: string
+): Promise<SourcemapDoctorResult> {
+  return fetchResource<SourcemapDoctorResult>(
+    `/services/${nsParam(namespace)}/${encodeURIComponent(service)}/sourcemap-doctor`,
+    { url: frameUrl }
+  );
+}
+
 /** Feedback captured via @nais/apm's captureFeedback(), newest first. */
 export async function getFeedback(
   namespace: string,

--- a/src/pages/tabs/frontend/components/ExceptionDrawer.test.tsx
+++ b/src/pages/tabs/frontend/components/ExceptionDrawer.test.tsx
@@ -46,6 +46,23 @@ const exceptionLine =
   'timestamp=2026-07-03T10:00:00Z kind=exception type=TypeError value="boom" hash=abc123 ' +
   'stacktrace="at foo (bar.js:1:1)" session_id=sess-1 browser_name=Firefox browser_version=140 app_name=my-app';
 
+// Same shape as exceptionLine but with a minified frame (deep column offset on
+// a hashed cdn.nav.no bundle) — trips the #60 heuristic.
+const minifiedExceptionLine =
+  'timestamp=2026-07-03T10:00:00Z kind=exception type=TypeError value="boom" hash=abc123 ' +
+  'stacktrace="at n (https://cdn.nav.no/team/app/1.2.3/assets/index-Bq7Za1.js:1:99213)" ' +
+  'session_id=sess-1 browser_name=Firefox browser_version=140 app_name=my-app';
+
+function minifiedFetchImpl(options: any) {
+  const query: string = options?.params?.query ?? '';
+  if (query.includes('hash=')) {
+    return of({
+      data: { data: { result: [{ stream: {}, values: [['1751536800000000000', minifiedExceptionLine]] }] } },
+    });
+  }
+  return of({ data: { data: { result: [] } } });
+}
+
 function lokiFetchImpl(options: any) {
   const query: string = options?.params?.query ?? '';
   if (query.includes('hash=')) {
@@ -355,6 +372,28 @@ describe('server issues (#84)', () => {
     renderServerDrawer();
 
     expect(await screen.findByText(/No matching server-log occurrences/)).toBeInTheDocument();
+  });
+});
+
+describe('minified-stack hint (#60)', () => {
+  it('shows a dismissible info alert with a diagnosis button and source-maps link on a minified stack', async () => {
+    mockFetch.mockImplementation(minifiedFetchImpl);
+    renderDrawer();
+    await screen.findByText(/boom/);
+
+    expect(await screen.findByText('This stack looks minified')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Run diagnosis/ })).toBeInTheDocument();
+
+    const link = screen.getByRole('link', { name: /About source maps/ });
+    expect(link).toHaveAttribute('href', 'https://doc.nais.io/observability/frontend/how-to/sourcemaps/');
+  });
+
+  it('does not show the minified alert for a clean, source-mapped stack', async () => {
+    // Default lokiFetchImpl serves "at foo (bar.js:1:1)" — a clean frame.
+    renderDrawer();
+    await screen.findByText(/boom/);
+
+    expect(screen.queryByText('This stack looks minified')).not.toBeInTheDocument();
   });
 });
 

--- a/src/pages/tabs/frontend/components/ExceptionDrawer.tsx
+++ b/src/pages/tabs/frontend/components/ExceptionDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   Button,
@@ -24,18 +24,21 @@ import {
   getTriageStates,
   postTriageAction,
   getFeedback,
+  getSourcemapDoctor,
   IssueSource,
   TriageState,
   FeedbackEntry,
+  SourcemapDoctorResult,
 } from '../../../../api/client';
 import { otel } from '../../../../otelconfig';
 import { PLUGIN_BASE_URL } from '../../../../constants';
 import { sanitizeLabelValue } from '../../../../utils/sanitize';
-import { apmDocs } from '../../../../utils/docsLinks';
+import { apmDocs, frontendDocs } from '../../../../utils/docsLinks';
 import { usePluginLabelOverrides, usePluginDatasources } from '../../../../utils/datasources';
 import { useTimeRange } from '../../../../utils/timeRange';
 import { buildExceptionTracesExploreUrl } from '../../../../utils/explore';
 import { StackTraceView, isConsoleCaptureValue } from './StackTraceView';
+import { stackLooksMinified, firstScriptUrl } from '../frames';
 import { useIssueOccurrences, msToNs, ParsedException } from '../useIssueOccurrences';
 import {
   parseLogfmt,
@@ -131,6 +134,11 @@ export function ExceptionDrawer({
   const [replayProbe, setReplayProbe] = useState<ReplayProbeResult | null>(null);
   const [creatingAlert, setCreatingAlert] = useState(false);
   const [feedback, setFeedback] = useState<FeedbackEntry[]>([]);
+  // Minified-stack hint + source-map doctor (#60).
+  const [minifiedDismissed, setMinifiedDismissed] = useState(false);
+  const [diagnosing, setDiagnosing] = useState(false);
+  const [diagnosis, setDiagnosis] = useState<SourcemapDoctorResult | null>(null);
+  const [diagnosisError, setDiagnosisError] = useState<string | null>(null);
   // Server occurrences are picked by list index (no session identity).
   const [serverIndex, setServerIndex] = useState(0);
   const labelOverrides = usePluginLabelOverrides();
@@ -395,6 +403,36 @@ export function ExceptionDrawer({
         })
       : undefined;
 
+  // Minified-stack detection (#60): a heuristic over the rendered stack, plus
+  // the candidate bundle URL the source-map doctor can probe. Both memoized on
+  // the stack string so they don't recompute on every unrelated re-render.
+  const stacktrace = exception?.stacktrace;
+  const looksMinified = useMemo(() => (stacktrace ? stackLooksMinified(stacktrace) : false), [stacktrace]);
+  const scriptUrl = useMemo(() => (stacktrace ? firstScriptUrl(stacktrace) : undefined), [stacktrace]);
+
+  // Reset the doctor + dismissal when the shown stack changes.
+  useEffect(() => {
+    setMinifiedDismissed(false);
+    setDiagnosis(null);
+    setDiagnosisError(null);
+    setDiagnosing(false);
+  }, [stacktrace]);
+
+  const runDiagnosis = async () => {
+    if (!scriptUrl) {
+      return;
+    }
+    setDiagnosing(true);
+    setDiagnosisError(null);
+    try {
+      setDiagnosis(await getSourcemapDoctor(namespace, service, scriptUrl));
+    } catch (err) {
+      setDiagnosisError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setDiagnosing(false);
+    }
+  };
+
   return (
     <Drawer
       title={exception?.type || 'Exception Details'}
@@ -470,6 +508,34 @@ export function ExceptionDrawer({
                     </Tooltip>
                   )}
                 </h4>
+                {looksMinified && !minifiedDismissed && (
+                  <Alert severity="info" title="This stack looks minified" onRemove={() => setMinifiedDismissed(true)}>
+                    <div className={styles.minifiedAlert}>
+                      <span>
+                        Source maps weren&rsquo;t resolved at ingest, so frames show mangled names and deep column
+                        offsets. Fixing the ingest config only affects <strong>new</strong> exceptions — already-stored
+                        stacks stay minified.
+                      </span>
+                      <div className={styles.minifiedActions}>
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          icon="sync"
+                          disabled={diagnosing || !scriptUrl}
+                          onClick={runDiagnosis}
+                          tooltip={scriptUrl ? undefined : 'No cdn.nav.no bundle URL found in this stack'}
+                        >
+                          {diagnosing ? 'Running diagnosis…' : 'Run diagnosis'}
+                        </Button>
+                        <TextLink href={frontendDocs.sourcemaps()} external variant="bodySmall">
+                          About source maps
+                        </TextLink>
+                      </div>
+                      {diagnosisError && <span className={styles.minifiedError}>{diagnosisError}</span>}
+                      {diagnosis && <SourcemapChecklist result={diagnosis} />}
+                    </div>
+                  </Alert>
+                )}
                 <StackTraceView
                   stack={exception.stacktrace}
                   isConsoleCapture={isConsoleCaptureValue(exception.value)}
@@ -759,6 +825,34 @@ function MetaItem({ label, value, link, icon }: { label: string; value?: string;
           value
         )}
       </span>
+    </div>
+  );
+}
+
+/**
+ * Renders the source-map doctor's pass/fail checklist (#60). Pure presentation
+ * of the backend diagnosis — the plugin never resolves the stack itself.
+ */
+function SourcemapChecklist({ result }: { result: SourcemapDoctorResult }) {
+  const styles = useStyles2(getStyles);
+  const icon = (status: string) =>
+    status === 'pass' ? 'check-circle' : status === 'fail' ? 'exclamation-circle' : 'minus-circle';
+  const color = (status: string) => (status === 'pass' ? '#3ba55d' : status === 'fail' ? '#d1465c' : '#8c95a5');
+  return (
+    <div className={styles.checklist}>
+      <div className={styles.checklistSummary}>
+        {result.ok
+          ? 'Source map is published and fetchable — new exceptions on this build should resolve at ingest.'
+          : 'Source map is missing or unreachable — that is why this stack stayed minified.'}
+      </div>
+      {result.checks.map((check, idx) => (
+        <div key={idx} className={styles.checkRow}>
+          <Icon name={icon(check.status) as any} style={{ color: color(check.status) }} />
+          <span className={styles.checkName}>{check.name}</span>
+          {check.detail && <span className={styles.checkDetail}>{check.detail}</span>}
+        </div>
+      ))}
+      {result.sourceMapUrl && <div className={styles.checkDetail}>Map: {result.sourceMapUrl}</div>}
     </div>
   );
 }
@@ -1218,5 +1312,46 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   sectionDocsLink: css`
     margin-top: ${theme.spacing(0.5)};
+  `,
+  minifiedAlert: css`
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacing(1)};
+    font-size: ${theme.typography.bodySmall.fontSize};
+  `,
+  minifiedActions: css`
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(2)};
+  `,
+  minifiedError: css`
+    color: ${theme.colors.error.text};
+    font-size: ${theme.typography.bodySmall.fontSize};
+  `,
+  checklist: css`
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacing(0.5)};
+    padding: ${theme.spacing(1)};
+    border: 1px solid ${theme.colors.border.weak};
+    border-radius: ${theme.shape.radius.default};
+    background: ${theme.colors.background.primary};
+  `,
+  checklistSummary: css`
+    font-weight: ${theme.typography.fontWeightMedium};
+    margin-bottom: ${theme.spacing(0.5)};
+  `,
+  checkRow: css`
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(1)};
+  `,
+  checkName: css`
+    font-family: ${theme.typography.fontFamilyMonospace};
+    color: ${theme.colors.text.primary};
+  `,
+  checkDetail: css`
+    color: ${theme.colors.text.secondary};
+    word-break: break-all;
   `,
 });

--- a/src/pages/tabs/frontend/frames.test.ts
+++ b/src/pages/tabs/frontend/frames.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { isInAppFrame, parseStackFrame } from './frames';
+import { isInAppFrame, parseStackFrame, isLikelyMinifiedFrame, stackLooksMinified, firstScriptUrl } from './frames';
 
 interface FixtureCase {
   path: string;
@@ -64,5 +64,70 @@ describe('parseStackFrame', () => {
   it('treats blank and message lines as non-frames', () => {
     expect(parseStackFrame('').isFrame).toBe(false);
     expect(parseStackFrame('TypeError: x is undefined').isFrame).toBe(false);
+  });
+});
+
+describe('isLikelyMinifiedFrame (#60 heuristic)', () => {
+  it('flags a very deep column offset', () => {
+    expect(isLikelyMinifiedFrame('    at https://cdn.nav.no/team/app/1.2.3/assets/vendor-Cq2ZL9.js:2:48211')).toBe(
+      true
+    );
+  });
+
+  it('flags a hashed bundle with a mangled 1–2 char function name', () => {
+    expect(isLikelyMinifiedFrame('    at Kt (https://cdn.nav.no/team/app/1.2.3/assets/main-Dk3js9aP.js:1:200)')).toBe(
+      true
+    );
+  });
+
+  it('does not flag a clean app frame with real names and a shallow column', () => {
+    expect(isLikelyMinifiedFrame('  at handleSubmit (/personbruker/decorator-next/src/helpers/auth.ts:74:25)')).toBe(
+      false
+    );
+  });
+
+  it('does not flag a hashed bundle when the function name is meaningful and the column is shallow', () => {
+    expect(
+      isLikelyMinifiedFrame('  at renderApp (https://cdn.nav.no/team/app/1.2.3/assets/main-Dk3js9aP.js:1:42)')
+    ).toBe(false);
+  });
+
+  it('never flags non-frame lines', () => {
+    expect(isLikelyMinifiedFrame('TypeError: x is undefined')).toBe(false);
+    expect(isLikelyMinifiedFrame('')).toBe(false);
+  });
+});
+
+describe('stackLooksMinified', () => {
+  it('is true when any frame looks minified', () => {
+    const stack = [
+      'TypeError: undefined is not a function',
+      '  at n (https://cdn.nav.no/team/app/1.2.3/assets/index-Bq7Za1.js:1:99213)',
+      '  at /personbruker/shared/logger.ts:47:26',
+    ].join('\n');
+    expect(stackLooksMinified(stack)).toBe(true);
+  });
+
+  it('is false for a fully source-mapped stack', () => {
+    const stack = [
+      'Error: boom',
+      '  at handleClick (/personbruker/decorator-next/src/App.tsx:12:8)',
+      '  at onClick (/personbruker/shared/Button.tsx:5:3)',
+    ].join('\n');
+    expect(stackLooksMinified(stack)).toBe(false);
+  });
+});
+
+describe('firstScriptUrl', () => {
+  it('returns the first http(s) bundle URL without the line/column suffix', () => {
+    const stack = ['TypeError: boom', '  at n (https://cdn.nav.no/team/app/1.2.3/assets/index-Bq7Za1.js:1:99213)'].join(
+      '\n'
+    );
+    expect(firstScriptUrl(stack)).toBe('https://cdn.nav.no/team/app/1.2.3/assets/index-Bq7Za1.js');
+  });
+
+  it('returns undefined for webpack:// or bare-path stacks', () => {
+    const stack = ['Error: boom', '  at ? (webpack://_N_E/../src/logger.ts:15:0)'].join('\n');
+    expect(firstScriptUrl(stack)).toBeUndefined();
   });
 });

--- a/src/pages/tabs/frontend/frames.ts
+++ b/src/pages/tabs/frontend/frames.ts
@@ -74,6 +74,77 @@ export interface StackFrame {
 // is whatever sits inside the parens, or the rest of the line without them.
 const FRAME_RE = /^\s*at\s+(?:.*?\s+\()?(.*?)\)?$/;
 
+// --- Minified-frame detection (#60) -----------------------------------------
+//
+// Frontend source maps are resolved *server-side at ingest* (the Alloy
+// faro.receiver reads the .map and writes the resolved stack to Loki). When
+// that resolution didn't happen — misconfigured Alloy, missing/unpublished
+// .map, a build that never emitted one — the stored stack stays minified. We
+// can only *detect and explain* that here; the plugin never symbolicates.
+//
+// This is a deliberately loose heuristic that tolerates false positives: the
+// only consequence of a wrong guess is an extra dismissible info hint.
+
+/** Columns this deep almost always come from a single minified line. */
+const MINIFIED_COLUMN_THRESHOLD = 300;
+
+/** A hashed content-addressed bundle name, e.g. `vendor-Cq2ZL9.js`, `main.4f3a2b1c.js`. */
+const HASHED_BUNDLE_RE = /[-.][A-Za-z0-9_]{6,}\.(?:js|mjs|cjs)$/i;
+
+/** A 1–2 character identifier — the mangled function names a minifier emits. */
+const SHORT_FUNC_RE = /^[A-Za-z$_][\w$]?$/;
+
+/** Parse the trailing `:line:col` column number from a frame line, if present. */
+function frameColumn(line: string): number | null {
+  const m = line.match(/:(\d+):(\d+)\)?\s*$/);
+  return m ? parseInt(m[2], 10) : null;
+}
+
+/** The function name in `at fn (path…)`, or '' for `at path` / anonymous frames. */
+function frameFunctionName(line: string): string {
+  const m = line.match(/^\s*at\s+(.+?)\s+\(/);
+  return m ? m[1].trim() : '';
+}
+
+/**
+ * Whether a single stack line looks like it came from an unresolved minified
+ * bundle. Signals (any strong one is enough): a very deep column offset, or a
+ * hashed bundle filename paired with a mangled (1–2 char) function name or a
+ * moderately deep column. Non-frame lines never match.
+ */
+export function isLikelyMinifiedFrame(line: string): boolean {
+  const frame = parseStackFrame(line);
+  if (!frame.isFrame) {
+    return false;
+  }
+  const col = frameColumn(line);
+  if (col !== null && col > MINIFIED_COLUMN_THRESHOLD) {
+    return true;
+  }
+  const hashed = HASHED_BUNDLE_RE.test(frame.path);
+  if (!hashed) {
+    return false;
+  }
+  const fn = frameFunctionName(line);
+  const mangledFn = fn !== '' && fn !== '?' && SHORT_FUNC_RE.test(fn);
+  return mangledFn || (col !== null && col > 120);
+}
+
+/** Whether any frame in a rendered stack trace looks minified. */
+export function stackLooksMinified(stack: string): boolean {
+  return stack.split('\n').some(isLikelyMinifiedFrame);
+}
+
+/**
+ * The first http(s) script URL referenced by a stack trace (line/column
+ * suffix stripped) — the candidate the source-map doctor probes. Returns
+ * undefined for stacks with only webpack:// or bare source paths.
+ */
+export function firstScriptUrl(stack: string): string | undefined {
+  const m = stack.match(/https?:\/\/[^\s()]+?\.(?:js|mjs|cjs)/i);
+  return m ? m[0] : undefined;
+}
+
 /** Strip a trailing :line:col (or :line) suffix from a frame location. */
 function stripPosition(location: string): string {
   return location.replace(/(?::\d+)+$/, '');

--- a/src/utils/docsLinks.test.ts
+++ b/src/utils/docsLinks.test.ts
@@ -1,4 +1,4 @@
-import { docsUrl, apmDocs, DOCS_BASE_URL, APM_SDK_REPO_URL } from './docsLinks';
+import { docsUrl, apmDocs, frontendDocs, DOCS_BASE_URL, APM_SDK_REPO_URL } from './docsLinks';
 
 describe('docsUrl', () => {
   it('builds a trailing-slash URL against the default public base', () => {
@@ -44,5 +44,13 @@ describe('apmDocs builders', () => {
     expect(apmDocs.issuesModel()).toBe('https://doc.nais.io/observability/apm/reference/issues-model/');
     expect(apmDocs.urlContract()).toBe('https://doc.nais.io/observability/apm/reference/url-contract/');
     expect(apmDocs.howNaisApmWorks()).toBe('https://doc.nais.io/observability/apm/explanations/how-nais-apm-works/');
+  });
+});
+
+describe('frontendDocs builders', () => {
+  it('links the source-maps guideline under the frontend (not apm) docs section', () => {
+    // #60: the sourcemaps doc lives under observability/frontend, a different
+    // section from the observability/apm slugs.
+    expect(frontendDocs.sourcemaps()).toBe('https://doc.nais.io/observability/frontend/how-to/sourcemaps/');
   });
 });

--- a/src/utils/docsLinks.ts
+++ b/src/utils/docsLinks.ts
@@ -56,3 +56,20 @@ export const apmDocs = {
   // Explanations
   howNaisApmWorks: () => docsUrl(`${APM}/explanations/how-nais-apm-works`),
 } as const;
+
+/**
+ * Frontend-observability docs section root. This is a DIFFERENT section from
+ * `observability/apm` — the source-maps guideline is owned by the frontend
+ * observability docs, not the APM docs — so it composes its own base.
+ */
+const FRONTEND = 'observability/frontend';
+
+/**
+ * Docs that live outside the APM section but are linked from APM plugin UI.
+ * Keep these separate from `apmDocs` so the differing section root stays
+ * explicit at the call site.
+ */
+export const frontendDocs = {
+  // How-to: fixing minified frontend stacks (source-map resolution at ingest).
+  sourcemaps: () => docsUrl(`${FRONTEND}/how-to/sourcemaps`),
+} as const;


### PR DESCRIPTION
## What

Plugin-side diagnostics for issue #60 (Faro source maps). When a stored
frontend stack is still minified, the plugin now **detects and explains** it
and offers a server-side "doctor" that checks whether the bundle's source map
is actually published.

### Scope / constraint
Frontend-stack deobfuscation happens **server-side at ingest** — Alloy's
`faro.receiver` resolves the `.map` and writes the resolved stack to Loki. This
PR is purely the plugin **diagnostics UX**: it never resolves/symbolicates
stacks itself (explicit non-goal), and fixing the config only affects **new**
exceptions — already-stored stacks stay minified.

## Changes
- **Minified-frame detection** (`src/pages/tabs/frontend/frames.ts`):
  `isLikelyMinifiedFrame` / `stackLooksMinified` heuristic — deep column
  offsets, mangled 1–2 char function names, hashed bundle filenames. Tolerates
  false positives (worst case is one dismissible hint). Plus `firstScriptUrl()`
  to pick the candidate bundle URL.
- **Drawer hint** (`ExceptionDrawer.tsx`): info-level, dismissible `Alert` in
  the Stack Trace section, with a "Run diagnosis" button and a link to the
  sourcemaps guideline.
- **Docs link** (`src/utils/docsLinks.ts`): `frontendDocs.sourcemaps()` under
  `observability/frontend/how-to/sourcemaps` (a different docs section from the
  `observability/apm` slugs).
- **Doctor endpoint** (`pkg/plugin/sourcemapdoctor.go`):
  `GET /services/{namespace}/{service}/sourcemap-doctor?url=<frameJsUrl>` —
  server-side fetch of the bundle from cdn.nav.no, returning a pass/fail
  checklist: bundle fetchable, `//# sourceMappingURL=` present, referenced
  `.map` fetchable. OpenAPI path + schema added (route-drift test stays green).

## SSRF guard
The one handler that fetches a caller-supplied URL. Defense in depth:
- The initial `url` must be an absolute `http(s)` URL whose host is exactly
  `cdn.nav.no` (case-insensitive, port ignored) — rejected with 400 otherwise,
  before any outbound request.
- The resolved `.map` URL host is re-validated against the same allowlist (a
  relative map stays on-CDN; an absolute cross-host map is refused, not
  fetched).
- A `CheckRedirect` hook blocks any redirect hop that leaves the allowlist and
  caps redirects. Reuses the shared outbound client's transport/timeout.
- Response bodies are read through a `LimitReader` cap.

## Tests
- Go: doctor handler + `diagnoseSourcemap` (map present → pass; 404 → fail;
  missing `sourceMappingURL` → fail; unfetchable `.map` → fail; host-allowlist
  unit table; non-cdn host → 400; missing url → 400).
- Frontend: the minified heuristic (unit) + the Alert renders on a minified
  stack and not on a clean one + the `frontendDocs.sourcemaps()` slug.
- `mise run all` green.

## Companion pieces (out of scope here)
- **Platform / cross-repo:** the Alloy `faro.receiver` ingest-config change
  that actually resolves `.map` files at ingest — owned by the platform team.
- **Docs:** the `observability/frontend/how-to/sourcemaps.md` guideline update
  (handled separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrhS5Cdqorxmc6zcB9R6jq