### PR TITLE
ci(deps): defer eslint 10, react-router 7, react-hooks 7.1 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,23 @@ updates:
         versions: ['>=19.0.0']
       - dependency-name: '@types/react-dom'
         versions: ['>=19.0.0']
+      # ESLint 10 ecosystem — eslint-plugin-react has no ESLint 10 support yet
+      # (crashes); defer until the plugin ecosystem catches up.
+      - dependency-name: 'eslint'
+        versions: ['>=10.0.0']
+      - dependency-name: '@grafana/eslint-config'
+        versions: ['>=10.0.0']
+      # react-hooks 7.1 adds set-state-in-effect, which flags existing effects —
+      # a refactor, not a dep bump; defer.
+      - dependency-name: 'eslint-plugin-react-hooks'
+        versions: ['>=7.1.0']
+      # React Router 7 — breaks Grafana's react-router-dom-v5-compat shim
+      # (the repo pins react-router 6.30.4 via overrides); defer to a Grafana
+      # version whose compat shim supports v7.
+      - dependency-name: 'react-router'
+        versions: ['>=7.0.0']
+      - dependency-name: 'react-router-dom'
+        versions: ['>=7.0.0']
     groups:
       npm-all:
         patterns:


### PR DESCRIPTION
Adds dependabot ignore rules for the three blocked breaking majors surfaced by #55 — coordinated ecosystem upgrades, not fixable inside a group PR:

- **eslint 10** (+ `@grafana/eslint-config` 10) — `eslint-plugin-react` has no ESLint 10 support yet (crashes).
- **react-router / react-router-dom 7** — breaks Grafana's `react-router-dom-v5-compat` shim (repo pins react-router 6.30.4 via overrides).
- **eslint-plugin-react-hooks ≥7.1** — 7.1 adds `set-state-in-effect` (a refactor).

Same `versions: ['>=X']` style as the existing Grafana-13 / React-19 deferrals. Each gets a dedicated PR once upstream support lands.