### PR TITLE
ci: fix merge queue deadlock — run CI on merge_group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - master
       - main
+  # Required so the CI jobs (notably the required `publish-report` check) run on
+  # the merge queue's synthetic merge_group branch. Without this the queue waits
+  # forever for a check that never fires.
+  merge_group:
 
 jobs:
   frontend:


### PR DESCRIPTION
**Fixes the stuck merge queue.** The queue's only required status check is `publish-report`, produced by `ci.yml` — but `ci.yml` only triggered on `push`/`pull_request`. GitHub's merge queue fires a **`merge_group`** event on its synthetic merge branch; with no `merge_group` trigger, `ci.yml` never ran there, so `publish-report` never reported and every queued PR waited forever.

Adds `merge_group:` to `ci.yml`'s triggers so CI (and `publish-report`) runs on the queue branch.

⚠️ **Deadlock-break:** this PR can't merge *through* the stuck queue (it'd wait on the same missing check). It needs a **direct/admin merge** (bypass the queue) to land on `main`; after that, the queued PRs' merge branches will run CI and drain normally.