### PR TITLE
feat(alerts): read-only firing-alert detail drawer (#32)

### DIFF
--- a/docs/url-contract.md
+++ b/docs/url-contract.md
@@ -73,6 +73,24 @@ or absent value means no filter.
 | ----- | ---------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `slo` | `0.99` \| `0.995` \| `0.999` \| `0.9999` | Selected SLO target for the error-budget panel. Any other value falls back to `0.999` (default). |
 
+## Firing-alert drawer (Alerts tab)
+
+The #32 firing-alert detail drawer opens purely from URL state, so a firing
+alert is shareable as a deep link without a new route:
+
+```
+/a/nais-apm-app/services/{namespace}/{service}?tab=alerts&environment={env}&firingAlert={ruleName}
+```
+
+| Param         | Meaning                                                                                                                                                                                                                                                                                                                                                     |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `firingAlert` | Alert **rule name** (not a UID — the ruler→Grafana rule-UID join is out of scope, #33 Phase 2). Opens the read-only detail drawer for that rule, resolved against the Alerts tab's already-loaded rule set (`getServiceAlerts`) — no extra fetch. When the name resolves to no firing rule (state cleared, rule gone), the drawer degrades to "state unavailable". |
+
+The drawer's own outbound links reuse existing contracts: the RED-panel link
+targets `tab=backend&from={activeAt-15m}&to=now`, and the best-effort
+related-Issue link uses `issueId`/`exceptionHash` (above) — emitted **only**
+when an instance label confidently resolves to an issue identity.
+
 ## Exception drawer (Issues tab + Frontend tab)
 
 The ExceptionDrawer opens purely from URL state — this is the deep-link target

--- a/pkg/plugin/alerts.go
+++ b/pkg/plugin/alerts.go
@@ -291,6 +291,9 @@ func alertRuleSummary(rule queries.Rule, group queries.RuleGroup, source string)
 		ActiveCount:        activeCount,
 		GroupName:          group.Name,
 		Source:             source,
+		Expression:         rule.Query,
+		ForDuration:        rule.Duration,
+		RunbookURL:         rule.Annotations["runbook_url"],
 		Instances:          instances,
 		InstancesTruncated: truncated,
 	}

--- a/pkg/plugin/alerts_test.go
+++ b/pkg/plugin/alerts_test.go
@@ -563,11 +563,13 @@ func TestHandleServiceAlerts_FiringInstances(t *testing.T) {
 			File: "dev/teamorders/orders-alerts/abc123",
 			Rules: []queries.Rule{
 				{
-					Type:   "alerting",
-					Name:   "OrdersHighErrorRate",
-					Query:  `sum(rate(calls_total{service_name="orders"}[5m])) > 0.05`,
-					State:  "firing",
-					Labels: map[string]string{"namespace": "teamorders", "severity": "critical"},
+					Type:        "alerting",
+					Name:        "OrdersHighErrorRate",
+					Query:       `sum(rate(calls_total{service_name="orders"}[5m])) > 0.05`,
+					Duration:    300,
+					State:       "firing",
+					Labels:      map[string]string{"namespace": "teamorders", "severity": "critical"},
+					Annotations: map[string]string{"runbook_url": "https://runbooks.example/orders"},
 					Alerts: []queries.Alert{
 						{
 							State:    "firing",
@@ -657,6 +659,17 @@ func TestHandleServiceAlerts_FiringInstances(t *testing.T) {
 	}
 	if checkout.State != "firing" {
 		t.Errorf("checkout instance state = %q, want firing", checkout.State)
+	}
+	// The #32 drawer fields ride along on the summary: raw expression, the
+	// `for` window (seconds), and the runbook_url annotation surfaced verbatim.
+	if firing.Expression != `sum(rate(calls_total{service_name="orders"}[5m])) > 0.05` {
+		t.Errorf("firing expression = %q, want the rule query", firing.Expression)
+	}
+	if firing.ForDuration != 300 {
+		t.Errorf("firing forDuration = %v, want 300", firing.ForDuration)
+	}
+	if firing.RunbookURL != "https://runbooks.example/orders" {
+		t.Errorf("firing runbookUrl = %q, want the runbook_url annotation", firing.RunbookURL)
 	}
 
 	pending, ok := byName["OrdersLatency"]

--- a/pkg/plugin/models.go
+++ b/pkg/plugin/models.go
@@ -166,6 +166,16 @@ type AlertRuleSummary struct {
 	ActiveCount int    `json:"activeCount"`
 	GroupName   string `json:"groupName"`
 	Source      string `json:"source,omitempty"` // "mimir" (ruler) or "grafana" (unified alerting)
+	// Expression is the rule's raw PromQL/LogQL query, surfaced for the #32
+	// firing-alert drawer's collapsible condition block. Empty when the ruler
+	// omits it.
+	Expression string `json:"expression,omitempty"`
+	// ForDuration is the rule's `for` window in seconds (how long the condition
+	// must hold before firing) — the evaluation window shown in the drawer.
+	ForDuration float64 `json:"forDuration,omitempty"`
+	// RunbookURL is the standard runbook_url annotation, surfaced verbatim as a
+	// button in the drawer (#32). Empty when the rule sets no runbook.
+	RunbookURL string `json:"runbookUrl,omitempty"`
 	// Instances carries the per-instance firing detail (value vs threshold,
 	// matched labels) for the active alerts, capped at alertInstanceCap (#33).
 	Instances []AlertInstance `json:"instances,omitempty"`

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -406,6 +406,12 @@ export interface AlertRuleSummary {
   groupName: string;
   /** Where the rule is defined: Mimir ruler or Grafana unified alerting. */
   source?: 'mimir' | 'grafana';
+  /** Raw PromQL/LogQL query, for the drawer's collapsible condition block (#32). */
+  expression?: string;
+  /** The rule's `for` window in seconds (how long the condition must hold). */
+  forDuration?: number;
+  /** Standard runbook_url annotation, surfaced verbatim as a button (#32). */
+  runbookUrl?: string;
   /** Per-instance firing detail (value vs threshold, matched labels), capped (#33). */
   instances?: AlertInstance[];
   /** True when more active instances existed than the server-side cap surfaced. */

--- a/src/pages/tabs/AlertsTab.test.tsx
+++ b/src/pages/tabs/AlertsTab.test.tsx
@@ -13,7 +13,7 @@ jest.mock('../../api/client', () => ({
 
 const mockPush = jest.fn();
 jest.mock('@grafana/runtime', () => ({
-  getBackendSrv: () => ({ fetch: jest.fn() }),
+  getBackendSrv: () => ({ fetch: jest.fn(), get: jest.fn().mockResolvedValue([]) }),
   getAppEvents: () => ({ publish: jest.fn() }),
   locationService: { push: (url: string) => mockPush(url) },
 }));
@@ -111,6 +111,75 @@ describe('AlertsTab (#32/#33 home)', () => {
     renderTab();
 
     await waitFor(() => expect(screen.getByText('Alert rules are currently unavailable.')).toBeInTheDocument());
+  });
+
+  it('opens the firing-alert detail drawer (#32) from a firing row', async () => {
+    getServiceAlerts.mockResolvedValue({
+      rules: [
+        {
+          name: 'OrdersHighErrorRate',
+          state: 'firing',
+          severity: 'critical',
+          summary: 'Orders erroring',
+          description: '',
+          activeSince: new Date(Date.now() - 20 * 60_000).toISOString(),
+          activeCount: 1,
+          groupName: 'orders-alerts',
+          source: 'grafana',
+          expression: 'sum(rate(calls_total[5m])) > 0.05',
+          forDuration: 300,
+          firingState: {
+            state: 'firing',
+            activeCount: 1,
+            instances: [{ state: 'firing', value: '0.12', labels: { endpoint: '/checkout' } }],
+            value: '0.12',
+          },
+        },
+      ],
+    });
+
+    renderTab();
+
+    // The firing rule name is a button that opens the drawer.
+    const trigger = await screen.findByRole('button', { name: 'OrdersHighErrorRate' });
+    fireEvent.click(trigger);
+
+    // Drawer content: the condition block appears.
+    await waitFor(() => expect(screen.getByText('Current value')).toBeInTheDocument());
+    expect(screen.getByText('Evaluation window')).toBeInTheDocument();
+  });
+
+  it('opens the drawer directly from a shared firingAlert URL param (#32)', async () => {
+    getServiceAlerts.mockResolvedValue({
+      rules: [
+        {
+          name: 'OrdersHighErrorRate',
+          state: 'firing',
+          severity: 'critical',
+          summary: 'Orders erroring',
+          description: '',
+          activeSince: new Date(Date.now() - 20 * 60_000).toISOString(),
+          activeCount: 1,
+          groupName: 'orders-alerts',
+          source: 'mimir',
+          firingState: {
+            state: 'firing',
+            activeCount: 1,
+            instances: [{ state: 'firing', value: '0.12', labels: { endpoint: '/checkout' } }],
+            value: '0.12',
+          },
+        },
+      ],
+    });
+
+    renderTab(['/?firingAlert=OrdersHighErrorRate']);
+
+    await waitFor(() => expect(screen.getByText('Current value')).toBeInTheDocument());
+    // Footer deep link uses the name-search fallback (no rule UID available).
+    expect(screen.getByRole('link', { name: /Open in Grafana Alerting/ })).toHaveAttribute(
+      'href',
+      '/alerting/list?search=OrdersHighErrorRate'
+    );
   });
 
   it('creates an alert via the template flow and navigates to the pre-filled editor', async () => {

--- a/src/pages/tabs/AlertsTab.tsx
+++ b/src/pages/tabs/AlertsTab.tsx
@@ -13,6 +13,8 @@ import {
 } from '../../api/client';
 import { apmDocs } from '../../utils/docsLinks';
 import { useFetch } from '../../utils/useFetch';
+import { useUrlParams } from '../../utils/useUrlState';
+import { FiringAlertDrawer } from './alerts/FiringAlertDrawer';
 
 interface AlertsTabProps {
   service: string;
@@ -83,10 +85,19 @@ const ALERT_TEMPLATES: AlertTemplateCard[] = [
  */
 export function AlertsTab({ service, namespace, environment }: AlertsTabProps) {
   const styles = useStyles2(getStyles);
-  const [, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const updateParams = useUrlParams();
 
   const { data, loading, error } = useFetch(() => getServiceAlerts(namespace, service), [namespace, service]);
   const rules = data?.rules ?? [];
+
+  // The #32 firing-alert detail drawer is opened purely from the URL
+  // (docs/url-contract.md): `firingAlert=<ruleName>` is shareable and resolves
+  // against the rule set this tab already loaded — no new fetch.
+  const firingAlert = searchParams.get('firingAlert') ?? '';
+  const selectedRule = firingAlert ? rules.find((r) => r.name === firingAlert) : undefined;
+  const openDrawer = useCallback((name: string) => updateParams({ firingAlert: name }), [updateParams]);
+  const closeDrawer = useCallback(() => updateParams({ firingAlert: null }), [updateParams]);
 
   const [creating, setCreating] = useState<string | null>(null);
   const createAlert = useCallback(
@@ -149,7 +160,7 @@ export function AlertsTab({ service, namespace, environment }: AlertsTabProps) {
             <div className={styles.emptyHint}>Create one below to get notified when this service degrades.</div>
           </div>
         ) : (
-          <AlertRulesTable rules={rules} styles={styles} />
+          <AlertRulesTable rules={rules} styles={styles} onOpenDetail={openDrawer} />
         )}
       </section>
 
@@ -201,11 +212,31 @@ export function AlertsTab({ service, namespace, environment }: AlertsTabProps) {
           </TextLink>
         </div>
       </section>
+
+      {firingAlert && (
+        <FiringAlertDrawer
+          rule={selectedRule}
+          ruleName={firingAlert}
+          namespace={namespace}
+          service={service}
+          environment={environment}
+          loading={loading}
+          onClose={closeDrawer}
+        />
+      )}
     </div>
   );
 }
 
-function AlertRulesTable({ rules, styles }: { rules: ServiceAlertRule[]; styles: ReturnType<typeof getStyles> }) {
+function AlertRulesTable({
+  rules,
+  styles,
+  onOpenDetail,
+}: {
+  rules: ServiceAlertRule[];
+  styles: ReturnType<typeof getStyles>;
+  onOpenDetail: (ruleName: string) => void;
+}) {
   return (
     <table className={styles.table}>
       <thead>
@@ -217,31 +248,48 @@ function AlertRulesTable({ rules, styles }: { rules: ServiceAlertRule[]; styles:
         </tr>
       </thead>
       <tbody>
-        {rules.map((rule) => (
-          <tr key={`${rule.source ?? ''}:${rule.groupName}:${rule.name}`}>
-            <td>
-              <div className={styles.ruleName}>{rule.name}</div>
-              {(rule.summary || rule.description) && (
-                <div className={styles.ruleSummary}>{rule.summary || rule.description}</div>
-              )}
-            </td>
-            <td className={styles.narrowCol}>
-              {rule.source === 'grafana' ? (
-                <Badge text="grafana" color="blue" icon="bell" />
-              ) : (
-                <Badge text="mimir" color="purple" icon="graph-bar" />
-              )}
-            </td>
-            <td>
-              <FiringStateCell rule={rule} />
-            </td>
-            <td className={styles.narrowCol}>
-              <TextLink href={`/alerting/list?search=${encodeURIComponent(rule.name)}`} variant="bodySmall">
-                Open in Grafana
-              </TextLink>
-            </td>
-          </tr>
-        ))}
+        {rules.map((rule) => {
+          // A row is "actionable" (has a detail drawer to open) only when it is
+          // actively firing or pending (#32) — inactive rules have no instances.
+          const isActive = rule.firingState?.state === 'firing' || rule.firingState?.state === 'pending';
+          return (
+            <tr key={`${rule.source ?? ''}:${rule.groupName}:${rule.name}`}>
+              <td>
+                {isActive ? (
+                  <button type="button" className={styles.ruleNameButton} onClick={() => onOpenDetail(rule.name)}>
+                    {rule.name}
+                  </button>
+                ) : (
+                  <div className={styles.ruleName}>{rule.name}</div>
+                )}
+                {(rule.summary || rule.description) && (
+                  <div className={styles.ruleSummary}>{rule.summary || rule.description}</div>
+                )}
+              </td>
+              <td className={styles.narrowCol}>
+                {rule.source === 'grafana' ? (
+                  <Badge text="grafana" color="blue" icon="bell" />
+                ) : (
+                  <Badge text="mimir" color="purple" icon="graph-bar" />
+                )}
+              </td>
+              <td>
+                <FiringStateCell rule={rule} />
+              </td>
+              <td className={styles.narrowCol}>
+                {isActive ? (
+                  <Button size="sm" variant="secondary" fill="text" onClick={() => onOpenDetail(rule.name)}>
+                    Details
+                  </Button>
+                ) : (
+                  <TextLink href={`/alerting/list?search=${encodeURIComponent(rule.name)}`} variant="bodySmall">
+                    Open in Grafana
+                  </TextLink>
+                )}
+              </td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );
@@ -384,6 +432,18 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   ruleName: css`
     font-weight: ${theme.typography.fontWeightMedium};
+  `,
+  ruleNameButton: css`
+    font-weight: ${theme.typography.fontWeightMedium};
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    color: ${theme.colors.text.link};
+    text-align: left;
+    &:hover {
+      text-decoration: underline;
+    }
   `,
   ruleSummary: css`
     font-size: ${theme.typography.bodySmall.fontSize};

--- a/src/pages/tabs/alerts/FiringAlertDrawer.test.tsx
+++ b/src/pages/tabs/alerts/FiringAlertDrawer.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { FiringAlertDrawer } from './FiringAlertDrawer';
+import { ServiceAlertRule, deriveFiringState, AlertRuleSummary } from '../../../api/client';
+
+const mockGet = jest.fn();
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: () => ({ get: (...args: unknown[]) => mockGet(...args) }),
+}));
+
+beforeEach(() => {
+  mockGet.mockReset().mockResolvedValue([]);
+});
+
+function renderDrawer(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+function rule(overrides: Partial<AlertRuleSummary> = {}): ServiceAlertRule {
+  const summary: AlertRuleSummary = {
+    name: 'OrdersHighErrorRate',
+    state: 'firing',
+    severity: 'critical',
+    summary: 'Orders erroring',
+    description: 'More than 5% of requests failing',
+    activeSince: new Date(Date.now() - 30 * 60_000).toISOString(),
+    activeCount: 2,
+    groupName: 'orders-alerts',
+    source: 'grafana',
+    expression: 'sum(rate(calls_total{service_name="orders"}[5m])) > 0.05',
+    forDuration: 300,
+    runbookUrl: 'https://runbooks.example/orders',
+    instances: [
+      { state: 'firing', value: '0.12', labels: { endpoint: '/checkout', service: 'orders' } },
+      { state: 'firing', value: '0.08', labels: { endpoint: '/cart', service: 'orders' } },
+    ],
+    ...overrides,
+  };
+  return { ...summary, firingState: deriveFiringState(summary) };
+}
+
+describe('FiringAlertDrawer (#32)', () => {
+  it('renders the firing detail from the resolved rule', async () => {
+    renderDrawer(
+      <FiringAlertDrawer
+        rule={rule()}
+        ruleName="OrdersHighErrorRate"
+        namespace="teamorders"
+        service="orders"
+        environment="prod-gcp"
+        onClose={jest.fn()}
+      />
+    );
+
+    // Header: rule name, source badge, firing state.
+    expect(screen.getAllByText('OrdersHighErrorRate').length).toBeGreaterThan(0);
+    expect(screen.getByText('grafana')).toBeInTheDocument();
+    expect(screen.getByText('firing')).toBeInTheDocument();
+
+    // Condition: current value + eval window (from the `for` duration).
+    expect(screen.getByText('Current value')).toBeInTheDocument();
+    expect(screen.getByText('0.12')).toBeInTheDocument();
+    expect(screen.getByText('Evaluation window')).toBeInTheDocument();
+
+    // Instance labels rendered.
+    expect(screen.getByText(/endpoint="\/checkout"/)).toBeInTheDocument();
+    expect(screen.getByText(/endpoint="\/cart"/)).toBeInTheDocument();
+
+    // Annotations verbatim + runbook button.
+    expect(screen.getByText('More than 5% of requests failing')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Open runbook/ })).toBeInTheDocument();
+
+    // Footer: Grafana Alerting name-search fallback (no UID on the summary).
+    const grafanaLink = screen.getByRole('link', { name: /Open in Grafana Alerting/ });
+    expect(grafanaLink).toHaveAttribute('href', '/alerting/list?search=OrdersHighErrorRate');
+
+    // RED panel link scoped to the backend tab.
+    const redLink = screen.getByRole('link', { name: /Service metrics around the firing window/ });
+    expect(redLink.getAttribute('href')).toContain('tab=backend');
+  });
+
+  it('emits a related-Issue link only when a label confidently resolves', async () => {
+    renderDrawer(
+      <FiringAlertDrawer
+        rule={rule({
+          instances: [{ state: 'firing', value: '11', labels: { fingerprint: 'v1:9f2ab31c04d7e655' } }],
+        })}
+        ruleName="ExceptionSpike"
+        namespace="teamorders"
+        service="orders"
+        onClose={jest.fn()}
+      />
+    );
+
+    const issueLink = screen.getByRole('link', { name: /Related issue/ });
+    expect(issueLink.getAttribute('href')).toContain('issueId=v1%3A9f2ab31c04d7e655');
+  });
+
+  it('renders NO related-Issue link when labels do not resolve (no wrong link)', async () => {
+    renderDrawer(
+      <FiringAlertDrawer
+        rule={rule({ instances: [{ state: 'firing', value: '0.1', labels: { endpoint: '/checkout' } }] })}
+        ruleName="OrdersHighErrorRate"
+        namespace="teamorders"
+        service="orders"
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('link', { name: /Related issue/ })).not.toBeInTheDocument();
+  });
+
+  it('degrades to "state unavailable" when the rule cannot be resolved', async () => {
+    renderDrawer(
+      <FiringAlertDrawer
+        rule={undefined}
+        ruleName="OrdersHighErrorRate"
+        namespace="teamorders"
+        service="orders"
+        loading={false}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText(/Firing state is unavailable/)).toBeInTheDocument();
+    // Even degraded, the Grafana Alerting deep link is still offered.
+    expect(screen.getByRole('link', { name: /Open in Grafana Alerting/ })).toBeInTheDocument();
+  });
+
+  it('shows the last deploy before firing when a deploy annotation is found', async () => {
+    const activeAtMs = Date.now() - 30 * 60_000;
+    mockGet.mockResolvedValue([
+      { time: activeAtMs - 5 * 60_000, text: 'ignored', tags: ['nais-apm:deploy', 'version:1.2.3'] },
+      { time: activeAtMs + 60_000, text: 'after', tags: ['nais-apm:deploy', 'version:1.2.4'] },
+    ]);
+
+    renderDrawer(
+      <FiringAlertDrawer
+        rule={rule({ activeSince: new Date(activeAtMs).toISOString() })}
+        ruleName="OrdersHighErrorRate"
+        namespace="teamorders"
+        service="orders"
+        onClose={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText(/Last deploy before firing/)).toBeInTheDocument());
+    // The deploy AFTER activeAt must be excluded — only 1.2.3 qualifies.
+    expect(screen.getByText('1.2.3')).toBeInTheDocument();
+    expect(screen.queryByText('1.2.4')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/tabs/alerts/FiringAlertDrawer.tsx
+++ b/src/pages/tabs/alerts/FiringAlertDrawer.tsx
@@ -1,0 +1,476 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { getBackendSrv } from '@grafana/runtime';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Badge, Button, ControlledCollapse, Drawer, Icon, Spinner, TextLink, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { ServiceAlertRule } from '../../../api/client';
+import { PLUGIN_BASE_URL } from '../../../constants';
+import { resolveIssueLink } from './resolveIssueLink';
+
+interface FiringAlertDrawerProps {
+  /** The rule the `firingAlert` param resolved to, or undefined when it matched
+   * nothing in the current rule set (drawer degrades to "unavailable"). */
+  rule?: ServiceAlertRule;
+  /** The rule name from the URL param — shown in the header even when the rule
+   * could not be resolved. */
+  ruleName: string;
+  namespace: string;
+  service: string;
+  environment?: string;
+  /** True while the alerts fetch that resolves `rule` is still in flight. */
+  loading?: boolean;
+  onClose: () => void;
+}
+
+/** How many firing instances to render before collapsing the rest behind a hint. */
+const INSTANCE_DISPLAY_CAP = 10;
+
+/**
+ * Read-only firing-alert detail drawer (#32). Opened purely from the
+ * `firingAlert=<ruleName>` URL param (docs/url-contract.md) so it is shareable,
+ * and reuses the ExceptionDrawer's chrome/interaction model for consistency.
+ *
+ * It renders over the inline firing state #33 Phase 1 already surfaces
+ * (ServiceAlertRule.firingState + expression/forDuration/runbookUrl) — no new
+ * backend fetch for the basics. Deploy correlation and the related-Issue link
+ * are best-effort side fetches that degrade silently.
+ *
+ * Capability-gated: when the rule can't be resolved or carries no firing state,
+ * it degrades to a "state unavailable" notice rather than erroring the page.
+ */
+export function FiringAlertDrawer({
+  rule,
+  ruleName,
+  namespace,
+  service,
+  environment,
+  loading = false,
+  onClose,
+}: FiringAlertDrawerProps) {
+  const styles = useStyles2(getStyles);
+  const fs = rule?.firingState;
+  const active = fs?.state === 'firing' || fs?.state === 'pending';
+  const instances = useMemo(() => fs?.instances ?? [], [fs]);
+  const activeAtMs = fs?.activeSince ? Date.parse(fs.activeSince) : NaN;
+
+  // Best-effort: the last deploy annotation before the alert started firing —
+  // an alert firing shortly after a deploy is the single most useful
+  // correlation (#64 deploy-annotation contract, reused via its tag scheme).
+  const [lastDeploy, setLastDeploy] = useState<{ version: string; timeMs: number } | null>(null);
+  useEffect(() => {
+    if (!Number.isFinite(activeAtMs)) {
+      setLastDeploy(null);
+      return;
+    }
+    let cancelled = false;
+    fetchLastDeployBefore(service, environment, activeAtMs)
+      .then((deploy) => {
+        if (!cancelled) {
+          setLastDeploy(deploy);
+        }
+      })
+      .catch(() => {
+        // Deploy correlation is best-effort — no marker on failure.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [service, environment, activeAtMs]);
+
+  // Related-Issue link — only when an instance's labels confidently resolve to
+  // an issue identity, never a guessed one (#32).
+  const issueLink = useMemo(() => {
+    for (const inst of instances) {
+      const resolved = resolveIssueLink(inst.labels);
+      if (resolved) {
+        return resolved;
+      }
+    }
+    return null;
+  }, [instances]);
+
+  const nsSegment = encodeURIComponent(namespace || '_');
+  const envParam = environment ? `&environment=${encodeURIComponent(environment)}` : '';
+
+  // RED panel scoped to [activeAt-15m, now] — the firing window with lead-in.
+  const redFrom = Number.isFinite(activeAtMs) ? new Date(activeAtMs - 15 * 60_000).toISOString() : 'now-1h';
+  const redPanelUrl = `${PLUGIN_BASE_URL}/services/${nsSegment}/${encodeURIComponent(service)}?tab=backend&from=${encodeURIComponent(redFrom)}&to=now${envParam}`;
+
+  const issueUrl = issueLink
+    ? 'issueId' in issueLink
+      ? `${PLUGIN_BASE_URL}/services/${nsSegment}/${encodeURIComponent(service)}?tab=issues${envParam}&issueId=${encodeURIComponent(issueLink.issueId)}`
+      : `${PLUGIN_BASE_URL}/services/${nsSegment}/${encodeURIComponent(service)}?tab=frontend${envParam}&exceptionHash=${encodeURIComponent(issueLink.exceptionHash)}`
+    : null;
+
+  // "Open in Grafana Alerting": no rule UID is carried on the summary (the
+  // ruler→Grafana UID join is out of scope, #33 Phase 2), so we fall back to
+  // the name-search deep link, which always resolves.
+  const grafanaUrl = `/alerting/list?search=${encodeURIComponent(ruleName)}`;
+
+  const shown = instances.slice(0, INSTANCE_DISPLAY_CAP);
+  const overflow = instances.length - shown.length;
+
+  return (
+    <Drawer
+      title={ruleName || 'Firing alert'}
+      subtitle={rule?.summary || rule?.description || undefined}
+      onClose={onClose}
+      closeOnMaskClick={true}
+      size="md"
+    >
+      <div className={styles.container}>
+        {/* Header strip: source + state + duration */}
+        <div className={styles.headerStrip}>
+          {rule?.source === 'grafana' ? (
+            <Badge text="grafana" color="blue" icon="bell" />
+          ) : rule?.source === 'mimir' ? (
+            <Badge text="mimir" color="purple" icon="graph-bar" />
+          ) : null}
+          {fs?.state ? (
+            <Badge
+              text={fs.state}
+              color={fs.state === 'firing' ? 'red' : fs.state === 'pending' ? 'orange' : 'green'}
+            />
+          ) : null}
+          {active && fs?.activeSince && (
+            <span className={styles.meta}>firing for {formatDuration(fs.activeSince)}</span>
+          )}
+          {rule?.severity && <span className={styles.meta}>severity: {rule.severity}</span>}
+        </div>
+
+        {loading && !rule ? (
+          <div className={styles.notice}>
+            <Spinner inline /> Loading alert details…
+          </div>
+        ) : !rule || !fs || !fs.state ? (
+          // Capability-gated degrade: no firing data for this rule.
+          <div className={styles.notice}>
+            Firing state is unavailable for this alert. Open it in Grafana Alerting for the live state.
+          </div>
+        ) : (
+          <>
+            {/* Condition: current value + evaluation window; raw expression
+                collapsible (opaque PromQL/LogQL kept out of the way). */}
+            <section className={styles.section}>
+              <h4 className={styles.sectionTitle}>Condition</h4>
+              <div className={styles.kvGrid}>
+                {fs.value !== undefined && (
+                  <>
+                    <span className={styles.kvKey}>Current value</span>
+                    <span className={styles.kvVal}>{fs.value}</span>
+                  </>
+                )}
+                {rule.forDuration ? (
+                  <>
+                    <span className={styles.kvKey}>Evaluation window</span>
+                    <span className={styles.kvVal}>{formatSeconds(rule.forDuration)}</span>
+                  </>
+                ) : null}
+                <span className={styles.kvKey}>Active instances</span>
+                <span className={styles.kvVal}>{fs.activeCount}</span>
+              </div>
+              {rule.expression && (
+                <ControlledCollapse label="Raw expression" isOpen={false}>
+                  <pre className={styles.expr}>{rule.expression}</pre>
+                </ControlledCollapse>
+              )}
+            </section>
+
+            {/* Instance labels — capped/paginated for high-cardinality rules. */}
+            {instances.length > 0 && (
+              <section className={styles.section}>
+                <h4 className={styles.sectionTitle}>Firing instances ({fs.activeCount})</h4>
+                <div className={styles.instanceList}>
+                  {shown.map((inst, i) => (
+                    <div key={i} className={styles.instanceRow}>
+                      <span className={styles.instanceLabels}>
+                        {formatInstanceLabels(inst.labels) || '(no labels)'}
+                      </span>
+                      {inst.value !== undefined && <span className={styles.instanceValue}>= {inst.value}</span>}
+                    </div>
+                  ))}
+                </div>
+                {(overflow > 0 || fs.instancesTruncated) && (
+                  <span className={styles.meta}>
+                    {overflow > 0 ? `+${overflow} more shown in Grafana` : 'more instances than shown'}
+                    {fs.instancesTruncated ? ' (server-capped)' : ''}
+                  </span>
+                )}
+              </section>
+            )}
+
+            {/* Annotations, verbatim. */}
+            {(rule.summary || rule.description || rule.runbookUrl) && (
+              <section className={styles.section}>
+                <h4 className={styles.sectionTitle}>Annotations</h4>
+                {rule.summary && (
+                  <div className={styles.annotation}>
+                    <span className={styles.annotationKey}>summary</span>
+                    <span className={styles.annotationVal}>{rule.summary}</span>
+                  </div>
+                )}
+                {rule.description && (
+                  <div className={styles.annotation}>
+                    <span className={styles.annotationKey}>description</span>
+                    <span className={styles.annotationVal}>{rule.description}</span>
+                  </div>
+                )}
+                {rule.runbookUrl && (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    icon="book"
+                    onClick={() => window.open(rule.runbookUrl, '_blank', 'noopener,noreferrer')}
+                  >
+                    Open runbook
+                  </Button>
+                )}
+              </section>
+            )}
+
+            {/* Context strip: deploy correlation + RED panel + related Issue. */}
+            <section className={styles.section}>
+              <h4 className={styles.sectionTitle}>Context</h4>
+              <div className={styles.contextList}>
+                {lastDeploy && (
+                  <div className={styles.contextItem}>
+                    <Icon name="rocket" size="sm" />
+                    <span>
+                      Last deploy before firing: <strong>{lastDeploy.version}</strong> (
+                      {formatDuration(new Date(lastDeploy.timeMs).toISOString())} before)
+                    </span>
+                  </div>
+                )}
+                <div className={styles.contextItem}>
+                  <Icon name="chart-line" size="sm" />
+                  <a href={redPanelUrl} target="_blank" rel="noopener noreferrer" className={styles.contextLink}>
+                    Service metrics around the firing window
+                  </a>
+                </div>
+                {issueUrl && (
+                  <div className={styles.contextItem}>
+                    <Icon name="bug" size="sm" />
+                    <a href={issueUrl} target="_blank" rel="noopener noreferrer" className={styles.contextLink}>
+                      Related issue
+                    </a>
+                  </div>
+                )}
+              </div>
+            </section>
+          </>
+        )}
+
+        {/* Footer: Grafana Alerting deep link (name-search fallback). */}
+        <div className={styles.footer}>
+          <TextLink href={grafanaUrl} variant="bodySmall">
+            Open in Grafana Alerting
+          </TextLink>
+        </div>
+      </div>
+    </Drawer>
+  );
+}
+
+/**
+ * Best-effort fetch of the most recent deploy annotation strictly before
+ * `beforeMs`, reusing the #64 deploy-annotation tag scheme
+ * (`buildDeployAnnotationsLayer`). Returns null on any failure or no match.
+ */
+async function fetchLastDeployBefore(
+  service: string,
+  environment: string | undefined,
+  beforeMs: number
+): Promise<{ version: string; timeMs: number } | null> {
+  const tags = ['nais-apm:deploy', `service:${service}`];
+  // A multi-env selection can't be AND-ed via repeated tags — only scope to a
+  // single environment (matches the backend's fetchDeployAnnotations).
+  if (environment && !environment.includes(',')) {
+    tags.push(`env:${environment}`);
+  }
+  const annotations: Array<{ time: number; text: string; tags: string[] }> = await getBackendSrv().get(
+    '/api/annotations',
+    {
+      tags,
+      // Look back 7d before the alert started for the landing deploy.
+      from: beforeMs - 7 * 24 * 3600_000,
+      to: beforeMs,
+      limit: 100,
+    }
+  );
+  let best: { version: string; timeMs: number } | null = null;
+  for (const ann of annotations ?? []) {
+    if (ann.time >= beforeMs) {
+      continue;
+    }
+    const version = (ann.tags ?? []).find((t) => t.startsWith('version:'))?.slice('version:'.length) || ann.text;
+    if (!version) {
+      continue;
+    }
+    if (!best || ann.time > best.timeMs) {
+      best = { version, timeMs: ann.time };
+    }
+  }
+  return best;
+}
+
+/** Render an instance's label set as a compact `k="v"` list, dropping noisy
+ * internal labels (matches the Alerts tab cell). */
+function formatInstanceLabels(labels?: Record<string, string>): string {
+  if (!labels) {
+    return '';
+  }
+  return Object.entries(labels)
+    .filter(([k]) => k !== 'alertname' && !k.startsWith('__'))
+    .map(([k, v]) => `${k}="${v}"`)
+    .join(', ');
+}
+
+/** Human duration between an ISO timestamp and now ("5m", "2h", "3d"). */
+function formatDuration(isoString: string): string {
+  const then = Date.parse(isoString);
+  if (!Number.isFinite(then)) {
+    return isoString;
+  }
+  const diffMs = Math.max(0, Date.now() - then);
+  if (diffMs < 60_000) {
+    return 'less than a minute';
+  }
+  if (diffMs < 3_600_000) {
+    return `${Math.floor(diffMs / 60_000)}m`;
+  }
+  if (diffMs < 86_400_000) {
+    return `${Math.floor(diffMs / 3_600_000)}h`;
+  }
+  return `${Math.floor(diffMs / 86_400_000)}d`;
+}
+
+/** Render a `for` window given in seconds as a compact duration. */
+function formatSeconds(seconds: number): string {
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  if (seconds < 3600) {
+    return `${Math.round(seconds / 60)}m`;
+  }
+  return `${Math.round(seconds / 360) / 10}h`;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css`
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacing(2.5)};
+  `,
+  headerStrip: css`
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: ${theme.spacing(1)};
+  `,
+  meta: css`
+    font-size: ${theme.typography.bodySmall.fontSize};
+    color: ${theme.colors.text.secondary};
+  `,
+  notice: css`
+    font-size: ${theme.typography.bodySmall.fontSize};
+    color: ${theme.colors.text.secondary};
+    padding: ${theme.spacing(1)} 0;
+  `,
+  section: css`
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacing(1)};
+  `,
+  sectionTitle: css`
+    font-size: ${theme.typography.h5.fontSize};
+    font-weight: ${theme.typography.fontWeightMedium};
+    margin: 0;
+    border-bottom: 1px solid ${theme.colors.border.weak};
+    padding-bottom: ${theme.spacing(0.5)};
+  `,
+  kvGrid: css`
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: ${theme.spacing(0.5)} ${theme.spacing(2)};
+    font-size: ${theme.typography.bodySmall.fontSize};
+  `,
+  kvKey: css`
+    color: ${theme.colors.text.secondary};
+  `,
+  kvVal: css`
+    color: ${theme.colors.text.primary};
+    font-family: ${theme.typography.fontFamilyMonospace};
+  `,
+  expr: css`
+    background: ${theme.colors.background.secondary};
+    border: 1px solid ${theme.colors.border.weak};
+    border-radius: ${theme.shape.radius.default};
+    padding: ${theme.spacing(1)};
+    font-family: ${theme.typography.fontFamilyMonospace};
+    font-size: ${theme.typography.bodySmall.fontSize};
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    margin: 0;
+  `,
+  instanceList: css`
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacing(0.5)};
+  `,
+  instanceRow: css`
+    display: flex;
+    align-items: baseline;
+    gap: ${theme.spacing(1)};
+    font-family: ${theme.typography.fontFamilyMonospace};
+    font-size: ${theme.typography.bodySmall.fontSize};
+  `,
+  instanceLabels: css`
+    color: ${theme.colors.text.primary};
+    word-break: break-all;
+  `,
+  instanceValue: css`
+    color: ${theme.colors.text.secondary};
+    white-space: nowrap;
+  `,
+  annotation: css`
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacing(0.25)};
+    font-size: ${theme.typography.bodySmall.fontSize};
+  `,
+  annotationKey: css`
+    color: ${theme.colors.text.secondary};
+    font-family: ${theme.typography.fontFamilyMonospace};
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.05em;
+  `,
+  annotationVal: css`
+    color: ${theme.colors.text.primary};
+    white-space: pre-wrap;
+    word-break: break-word;
+  `,
+  contextList: css`
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacing(0.75)};
+  `,
+  contextItem: css`
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(1)};
+    font-size: ${theme.typography.bodySmall.fontSize};
+    color: ${theme.colors.text.secondary};
+  `,
+  contextLink: css`
+    color: ${theme.colors.text.link};
+    text-decoration: underline;
+  `,
+  footer: css`
+    display: flex;
+    justify-content: flex-end;
+    padding-top: ${theme.spacing(1.5)};
+    border-top: 1px solid ${theme.colors.border.weak};
+  `,
+});

--- a/src/pages/tabs/alerts/resolveIssueLink.test.ts
+++ b/src/pages/tabs/alerts/resolveIssueLink.test.ts
@@ -1,0 +1,42 @@
+import { resolveIssueLink } from './resolveIssueLink';
+
+describe('resolveIssueLink (#32 label→issue resolver)', () => {
+  it('resolves a fingerprint under a known key to an issueId', () => {
+    expect(resolveIssueLink({ fingerprint: 'v1:9f2ab31c04d7e655', service: 'orders' })).toEqual({
+      issueId: 'v1:9f2ab31c04d7e655',
+    });
+  });
+
+  it('resolves a bare versioned-fingerprint value under any key', () => {
+    // Some rules label-group by fingerprint under a non-standard key; the
+    // versioned shape is distinctive enough to trust.
+    expect(resolveIssueLink({ grp: 'v2:aabbccddee', endpoint: '/checkout' })).toEqual({ issueId: 'v2:aabbccddee' });
+  });
+
+  it('resolves a Faro exception hash to an exceptionHash', () => {
+    expect(resolveIssueLink({ hash: 'a1b2c3d4e5f6', service: 'orders' })).toEqual({ exceptionHash: 'a1b2c3d4e5f6' });
+  });
+
+  it('prefers a fingerprint over a hash when both are present', () => {
+    expect(resolveIssueLink({ fingerprint: 'v1:deadbeefcafe', hash: 'a1b2c3d4e5f6' })).toEqual({
+      issueId: 'v1:deadbeefcafe',
+    });
+  });
+
+  it('returns null with no confident match — an ordinary label set', () => {
+    // The most important case: never emit a wrong link. Plain infra labels
+    // (endpoint, severity, service) carry no issue identity.
+    expect(resolveIssueLink({ endpoint: '/checkout', severity: 'critical', service: 'orders' })).toBeNull();
+  });
+
+  it('returns null for a short/non-hex value under a hash key', () => {
+    // Guards against a bogus link: a `hash` label that isn't hash-shaped.
+    expect(resolveIssueLink({ hash: 'prod' })).toBeNull();
+    expect(resolveIssueLink({ hash: 'v1' })).toBeNull();
+  });
+
+  it('returns null for undefined / empty labels', () => {
+    expect(resolveIssueLink(undefined)).toBeNull();
+    expect(resolveIssueLink({})).toBeNull();
+  });
+});

--- a/src/pages/tabs/alerts/resolveIssueLink.ts
+++ b/src/pages/tabs/alerts/resolveIssueLink.ts
@@ -1,0 +1,58 @@
+/**
+ * Best-effort resolver from a firing alert instance's labels to a related Issue
+ * deep link (#32). This is deliberately conservative: it only returns a link
+ * when a label CONFIDENTLY carries an issue identity, because a wrong link is
+ * worse than none (the on-call engineer would chase the wrong error).
+ *
+ * Two identities are recognised, matching the drawer/url-contract (#62, #69):
+ *   - a versioned fingerprint (`v1:9f2ab31c04d7e655`) → `issueId`
+ *   - a legacy Faro/Alloy exception hash → `exceptionHash`
+ *
+ * Both are validated by value shape, not merely by key presence — a rule that
+ * happens to carry an unrelated `hash` label won't produce a bogus link.
+ */
+
+/** Versioned fingerprint identity, e.g. `v1:9f2ab31c04d7e655` (#62). */
+const FINGERPRINT_RE = /^v\d+:[0-9a-f]{6,}$/i;
+/** Faro/Alloy exception hash: hex-ish, alphanumeric, reasonably long. */
+const HASH_RE = /^[0-9a-f]{8,}$/i;
+
+/** Label keys that, by convention, may carry a fingerprint identity. */
+const FINGERPRINT_KEYS = ['fingerprint', 'issueid', 'issue_id'];
+/** Label keys that, by convention, may carry a Faro exception hash. */
+const HASH_KEYS = ['hash', 'exception_hash', 'exceptionhash'];
+
+export type ResolvedIssueLink = { issueId: string } | { exceptionHash: string };
+
+/**
+ * Resolve alert instance labels to an issue deep-link identity, or null when no
+ * label confidently carries one. Fingerprint wins over hash (it's the richer,
+ * grouped identity), mirroring `serviceDeepLink` on the backend.
+ */
+export function resolveIssueLink(labels?: Record<string, string>): ResolvedIssueLink | null {
+  if (!labels) {
+    return null;
+  }
+
+  // A fingerprint can appear either under a known key or as a bare value that
+  // matches the versioned-fingerprint shape (some rules label-group by it).
+  for (const [key, value] of Object.entries(labels)) {
+    if (!value) {
+      continue;
+    }
+    if (FINGERPRINT_KEYS.includes(key.toLowerCase()) && FINGERPRINT_RE.test(value)) {
+      return { issueId: value };
+    }
+    if (FINGERPRINT_RE.test(value)) {
+      return { issueId: value };
+    }
+  }
+
+  for (const [key, value] of Object.entries(labels)) {
+    if (value && HASH_KEYS.includes(key.toLowerCase()) && HASH_RE.test(value)) {
+      return { exceptionHash: value };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
Closes #32.

A read-only detail drawer that explains a firing alert **in place**, so an on-call engineer sees what is firing, since when, at what value, for which instance, whether a deploy preceded it, and where to go next — without leaving the service page. Renders over the inline firing state #33 Phase 1 already surfaces (no new backend fetch for the basics).

## Entry & URL
- Opened from a firing/pending row in the Alerts tab (the rule name and a **Details** action) → `updateParams({ firingAlert })`.
- Shareable **`firingAlert=<ruleName>`** URL param (no new route); resolves against the already-loaded rule set. Documented in `docs/url-contract.md`.
- Reuses the `ExceptionDrawer` chrome/interaction model (`<Drawer>`, URL-driven open/close).

## Content
- **Header:** rule name, source badge (mimir/grafana), state + "firing for" duration since `activeAt`, severity.
- **Condition:** current value, evaluation window (`for`), active-instance count; raw PromQL/LogQL in a collapsible.
- **Instances:** capped/paginated label sets with values (server cap + UI cap both surfaced).
- **Annotations:** `summary`/`description` verbatim; `runbook_url` as a button.
- **Context strip:** last deploy before `activeAt` (reuses the #64 `nais-apm:deploy` annotation scheme, best-effort); a RED-panel link scoped to `tab=backend&from=activeAt-15m&to=now`; a best-effort related-Issue link **only** when instance labels confidently resolve to an `issueId`/`exceptionHash`.
- **Footer:** "Open in Grafana Alerting" via the `/alerting/list?search=<name>` name-search fallback (**no rule UID** is carried on the summary — the ruler→Grafana UID join is out of scope, #33 Phase 2).
- **Capability-gated:** degrades to "state unavailable" when firing data is missing, never errors the page.

## Backend (no new fetch)
`AlertRuleSummary` gains `expression`, `forDuration`, and `runbookUrl` — all already present in the ruler payload the summary is built from.

## UID deep-link decision
No rule UID is available on the summary and the ruler-API rule-UID join is explicitly out of scope, so the footer uses the existing `/alerting/list?search=<name>` deep link (noted in the drawer comment and the url-contract).

## Tests
- `resolveIssueLink.test.ts` — fingerprint/hash resolution **including the no-confident-match case** (never a wrong link).
- `FiringAlertDrawer.test.tsx` — firing render, related-Issue link present/absent, the degraded path, and deploy-before-`activeAt` correlation.
- `AlertsTab.test.tsx` — entry-point click and shared-URL-param open.
- `alerts_test.go` — asserts the new `expression`/`forDuration`/`runbookUrl` fields.

## Checks
`mise run all` can't run here (worktree mise.toml trust error), so the underlying checks were run directly, all green: `go test ./pkg/... -race` (667), `pnpm test:ci` (821), `tsc --noEmit`, `eslint .` (0 errors), production `pnpm build`.

## Out of scope (per plan)
Creating/editing alerts, silence creation, the Alertmanager silences read (#33 Phase 2), and the ruler-API rule-UID join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrhS5Cdqorxmc6zcB9R6jq