### PR TITLE
feat(issues): richer context for backend log occurrences

### DIFF
--- a/pkg/plugin/occurrences.go
+++ b/pkg/plugin/occurrences.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -37,6 +38,28 @@ const detectedLevelLabel = "detected_level"
 // configured backend-log version label to survey yet).
 const serverVersionLabel = "service_version"
 
+// traceIDLabel / spanIDLabel are the OTLP trace-correlation identifiers. On the
+// Loki OTLP endpoint they arrive as structured metadata (trace_id / span_id);
+// json and plaintext apps that emit correlation IDs commonly log the same field
+// names, so they are read best-effort across all three shapes. A populated
+// trace_id is what lets the drawer deep-link a thin log line to its full trace —
+// the spans / http / db / timing context the log line itself lacks.
+const (
+	traceIDLabel = "trace_id"
+	spanIDLabel  = "span_id"
+)
+
+// jsonBodyExclude are JSON-body fields already modeled on IssueOccurrence (or
+// pure noise) and therefore kept out of the free-form Attributes bag. Trace/span
+// aliases are excluded here because they are surfaced as TraceID/SpanID.
+var jsonBodyExclude = map[string]bool{
+	jsonMessageLabel: true, jsonMsgLabel: true, "level": true,
+	"stack_trace": true, "stack": true, "stacktrace": true, "exception": true,
+	"trace_id": true, "traceId": true, "traceID": true, "traceid": true,
+	"span_id": true, "spanId": true, "spanID": true, "spanid": true,
+	"timestamp": true, "time": true, "ts": true, "@timestamp": true,
+}
+
 // occurrenceCap bounds the per-shape line scan. Matches the drawer's browser
 // side (100 lines aggregated for impact); enough to characterize an issue
 // without pulling unbounded log volume.
@@ -53,6 +76,16 @@ type IssueOccurrence struct {
 	Stacktrace string `json:"stacktrace,omitempty"`
 	Version    string `json:"version,omitempty"`
 	Type       string `json:"type,omitempty"`
+	// TraceID / SpanID correlate this line to its distributed trace when the app
+	// logs them (always for OTLP logs; best-effort for json/plaintext). The
+	// drawer uses TraceID to deep-link the exact trace.
+	TraceID string `json:"traceId,omitempty"`
+	SpanID  string `json:"spanId,omitempty"`
+	// Attributes are the remaining structured-metadata / body fields the line
+	// carries (k8s container/node, logger, http.route/status, app-added fields)
+	// minus everything already modeled above. This is the extra context that
+	// makes thin shape (b)/(c) occurrences useful. Nil when the line adds nothing.
+	Attributes map[string]string `json:"attributes,omitempty"`
 }
 
 // IssueOccurrenceStats is the aggregate blast radius across the returned
@@ -76,7 +109,7 @@ func emptyOccurrenceStats() IssueOccurrenceStats {
 // IssueOccurrencesResponse is the /issues/occurrences payload: the raw server
 // occurrences for one fingerprint plus their aggregate stats.
 type IssueOccurrencesResponse struct {
-	Fingerprint string               `json:"fingerprint"`
+	Fingerprint string `json:"fingerprint"`
 	// Shape is the server-log shape the matched lines came from: "otlp"
 	// (semconv structured metadata), "json" (parsed body), or "plaintext".
 	Shape       string               `json:"shape,omitempty"`
@@ -189,18 +222,39 @@ func (a *App) queryIssueOccurrences(ctx context.Context, ds *queries.DsQueryClie
 		}
 	}
 
+	// Fields already modeled on IssueOccurrence — plus stream-identity labels
+	// implied by the drawer context (service / env / kind) — are excluded from
+	// the free-form Attributes bag so it carries only the extra context the line
+	// adds (k8s attrs, logger, http fields, app-added structured fields).
+	attrExclude := map[string]bool{
+		podLabel:                       true,
+		detectedLevelLabel:             true,
+		semconvTypeLabel:               true,
+		semconvMessageLabel:            true,
+		semconvStacktraceLabel:         true,
+		serverVersionLabel:             true,
+		traceIDLabel:                   true,
+		spanIDLabel:                    true,
+		jsonMessageLabel:               true,
+		jsonMsgLabel:                   true,
+		"level":                        true,
+		a.otelCfg.Labels.ServiceName:   true,
+		a.otelCfg.Labels.DeploymentEnv: true,
+		a.otelCfg.FaroLoki.Kind:        true,
+	}
+
 	// Shape (a) — OTLP/semconv structured metadata.
-	for _, l := range semExtract(semLines, wantFP) {
+	for _, l := range semExtract(semLines, wantFP, attrExclude) {
 		resp.Occurrences = append(resp.Occurrences, l)
 		setShape("otlp")
 	}
 	// Shape (b) — JSON body.
-	for _, l := range jsonExtract(jsonLines, wantFP) {
+	for _, l := range jsonExtract(jsonLines, wantFP, attrExclude) {
 		resp.Occurrences = append(resp.Occurrences, l)
 		setShape("json")
 	}
 	// Shape (c) — unstructured plain text.
-	for _, l := range plainExtract(plaLines, wantFP) {
+	for _, l := range plainExtract(plaLines, wantFP, attrExclude) {
 		resp.Occurrences = append(resp.Occurrences, l)
 		setShape("plaintext")
 	}
@@ -216,8 +270,9 @@ func (a *App) queryIssueOccurrences(ctx context.Context, ds *queries.DsQueryClie
 }
 
 // semExtract keeps the semconv lines whose (type, message) fingerprint matches,
-// reading stacktrace / pod / level / version from structured metadata.
-func semExtract(lines []queries.LogEntryWithLabels, wantFP string) []IssueOccurrence {
+// reading stacktrace / pod / level / version / trace correlation and the
+// remaining structured-metadata fields from the label set.
+func semExtract(lines []queries.LogEntryWithLabels, wantFP string, attrExclude map[string]bool) []IssueOccurrence {
 	out := make([]IssueOccurrence, 0, len(lines))
 	for _, l := range lines {
 		exType := l.Labels[semconvTypeLabel]
@@ -236,6 +291,9 @@ func semExtract(lines []queries.LogEntryWithLabels, wantFP string) []IssueOccurr
 			Stacktrace: l.Labels[semconvStacktraceLabel],
 			Version:    l.Labels[serverVersionLabel],
 			Type:       exType,
+			TraceID:    l.Labels[traceIDLabel],
+			SpanID:     l.Labels[spanIDLabel],
+			Attributes: occurrenceAttributes(l.Labels, attrExclude),
 		})
 	}
 	return out
@@ -244,7 +302,7 @@ func semExtract(lines []queries.LogEntryWithLabels, wantFP string) []IssueOccurr
 // jsonExtract parses each JSON body for its message (message|msg) and optional
 // stack trace (stack_trace|stack), matching on the message-only fingerprint —
 // the same key queryServerExceptionGroups grouped shape (b) under.
-func jsonExtract(lines []queries.LogEntryWithLabels, wantFP string) []IssueOccurrence {
+func jsonExtract(lines []queries.LogEntryWithLabels, wantFP string, attrExclude map[string]bool) []IssueOccurrence {
 	out := make([]IssueOccurrence, 0, len(lines))
 	for _, l := range lines {
 		body := map[string]json.RawMessage{}
@@ -269,12 +327,29 @@ func jsonExtract(lines []queries.LogEntryWithLabels, wantFP string) []IssueOccur
 		if level == "" {
 			level = l.Labels[detectedLevelLabel]
 		}
+		// Trace correlation: prefer structured metadata, fall back to a body
+		// field (many apps log trace_id / traceId inline in the JSON).
+		traceID := l.Labels[traceIDLabel]
+		if traceID == "" {
+			traceID = jsonFirstStr(body, "trace_id", "traceId", "traceID", "traceid")
+		}
+		spanID := l.Labels[spanIDLabel]
+		if spanID == "" {
+			spanID = jsonFirstStr(body, "span_id", "spanId", "spanID", "spanid")
+		}
+		// Context = structured-metadata fields (k8s attrs, logger) merged with the
+		// app's own scalar JSON fields (http.route/status, business context).
+		attrs := occurrenceAttributes(l.Labels, attrExclude)
+		attrs = mergeJSONAttributes(attrs, body)
 		out = append(out, IssueOccurrence{
 			TimeMs:     l.TimeMs,
 			Pod:        l.Labels[podLabel],
 			Level:      level,
 			Message:    msg,
 			Stacktrace: stack,
+			TraceID:    traceID,
+			SpanID:     spanID,
+			Attributes: attrs,
 		})
 	}
 	return out
@@ -282,7 +357,7 @@ func jsonExtract(lines []queries.LogEntryWithLabels, wantFP string) []IssueOccur
 
 // plainExtract keeps unstructured lines whose message-only fingerprint matches,
 // dropping the framework bootstrap noise the grouping path also filters out.
-func plainExtract(lines []queries.LogEntryWithLabels, wantFP string) []IssueOccurrence {
+func plainExtract(lines []queries.LogEntryWithLabels, wantFP string, attrExclude map[string]bool) []IssueOccurrence {
 	out := make([]IssueOccurrence, 0, len(lines))
 	for _, l := range lines {
 		msg := trimSpaceLimited(l.Line)
@@ -293,13 +368,91 @@ func plainExtract(lines []queries.LogEntryWithLabels, wantFP string) []IssueOccu
 			continue
 		}
 		out = append(out, IssueOccurrence{
-			TimeMs:  l.TimeMs,
-			Pod:     l.Labels[podLabel],
-			Level:   l.Labels[detectedLevelLabel],
-			Message: msg,
+			TimeMs:     l.TimeMs,
+			Pod:        l.Labels[podLabel],
+			Level:      l.Labels[detectedLevelLabel],
+			Message:    msg,
+			TraceID:    l.Labels[traceIDLabel],
+			SpanID:     l.Labels[spanIDLabel],
+			Attributes: occurrenceAttributes(l.Labels, attrExclude),
 		})
 	}
 	return out
+}
+
+// occurrenceAttributes folds a line's label set into the free-form Attributes
+// bag, dropping empty values, the modeled/identity keys in exclude, and Loki's
+// internal __*__ labels. Returns nil (not an empty map) when nothing remains so
+// the JSON omits the field and the drawer renders no empty section.
+func occurrenceAttributes(labels map[string]string, exclude map[string]bool) map[string]string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(labels))
+	for k, v := range labels {
+		if v == "" || exclude[k] || strings.HasPrefix(k, "__") {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// mergeJSONAttributes adds the app's own scalar JSON body fields (http.route,
+// status, logger, business context) into attrs, skipping fields already modeled
+// (jsonBodyExclude) and non-scalar values (nested objects/arrays are too noisy
+// for the context list). attrs may be nil; a map is allocated only if something
+// is added.
+func mergeJSONAttributes(attrs map[string]string, body map[string]json.RawMessage) map[string]string {
+	for k, raw := range body {
+		if jsonBodyExclude[k] {
+			continue
+		}
+		v, ok := jsonScalarStr(raw)
+		if !ok {
+			continue
+		}
+		if attrs == nil {
+			attrs = make(map[string]string)
+		}
+		attrs[k] = v
+	}
+	return attrs
+}
+
+// jsonFirstStr returns the first non-empty string value among the given keys.
+func jsonFirstStr(body map[string]json.RawMessage, keys ...string) string {
+	for _, k := range keys {
+		if v := jsonStr(body, k); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// jsonScalarStr renders a scalar JSON value (string, number, bool) as a string.
+// Objects, arrays, null, and empty values yield ok=false so they are skipped.
+func jsonScalarStr(raw json.RawMessage) (string, bool) {
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s == "null" {
+		return "", false
+	}
+	var str string
+	if err := json.Unmarshal(raw, &str); err == nil {
+		if str == "" {
+			return "", false
+		}
+		return str, true
+	}
+	// Non-string scalar (number/bool): keep the raw token. Objects/arrays and
+	// malformed strings are dropped.
+	if s[0] == '{' || s[0] == '[' || s[0] == '"' {
+		return "", false
+	}
+	return s, true
 }
 
 // jsonStr reads a string-valued JSON field, tolerating that the value may be a

--- a/pkg/plugin/occurrences_test.go
+++ b/pkg/plugin/occurrences_test.go
@@ -93,6 +93,11 @@ func TestQueryIssueOccurrencesSemconvShape(t *testing.T) {
 				"exception_type": "NullPointerException", "exception_message": "value is null",
 				"exception_stacktrace": "at Foo.bar(Foo.java:10)", "k8s_pod_name": "app-a",
 				"detected_level": "error", "service_version": "1.2.3",
+				// Trace correlation + extra structured-metadata context.
+				"trace_id": "abc123def456", "span_id": "span-9",
+				"k8s_container_name": "main", "logger": "com.example.Foo",
+				// Internal Loki label — must never leak into Attributes.
+				"__error__": "somefailure",
 			}},
 			{TimeMs: 3000, Labels: map[string]string{
 				"exception_type": "NullPointerException", "exception_message": "value is null",
@@ -128,6 +133,20 @@ func TestQueryIssueOccurrencesSemconvShape(t *testing.T) {
 	}
 	if o.Pod != "app-a" || o.Level != "error" || o.Version != "1.2.3" {
 		t.Errorf("pod/level/version = %q/%q/%q", o.Pod, o.Level, o.Version)
+	}
+	if o.TraceID != "abc123def456" || o.SpanID != "span-9" {
+		t.Errorf("trace/span = %q/%q, want abc123def456/span-9", o.TraceID, o.SpanID)
+	}
+	// Attributes carry the extra structured-metadata context, minus everything
+	// already modeled (pod/level/type/message/stacktrace/version/trace_id) and
+	// Loki's internal __*__ labels.
+	if o.Attributes["k8s_container_name"] != "main" || o.Attributes["logger"] != "com.example.Foo" {
+		t.Errorf("attributes missing extra context: %+v", o.Attributes)
+	}
+	for _, banned := range []string{"k8s_pod_name", "detected_level", "exception_type", "exception_message", "exception_stacktrace", "service_version", "trace_id", "span_id", "__error__"} {
+		if _, ok := o.Attributes[banned]; ok {
+			t.Errorf("attributes must not include modeled/internal key %q: %+v", banned, o.Attributes)
+		}
 	}
 	if resp.Stats.Total != 2 || resp.Stats.Pods != 2 {
 		t.Errorf("stats = %+v, want total=2 pods=2", resp.Stats)
@@ -183,12 +202,49 @@ func TestQueryIssueOccurrencesJSONShape(t *testing.T) {
 	}
 }
 
+// TestQueryIssueOccurrencesJSONTraceAndAttributes covers the richer-context
+// path for thin shape (b) lines: trace_id read from the JSON body (no structured
+// metadata), plus app-added scalar fields surfaced as Attributes while modeled
+// body fields (message/level/stack_trace) are excluded.
+func TestQueryIssueOccurrencesJSONTraceAndAttributes(t *testing.T) {
+	wantFP := fingerprint.Compute(fingerprint.Event{Value: "Failed to fetch decorator"}).Value
+
+	app, ds := occTestApp(t, map[string][]occLine{
+		keyJSON: {
+			{TimeMs: 5000, Line: `{"level":"warn","message":"Failed to fetch decorator","traceId":"body-trace-1","http_route":"/api/decorator","http_status":502,"logger":"decorator"}`,
+				Labels: map[string]string{"k8s_pod_name": "svc-1", "detected_level": "warn", "k8s_node_name": "node-7"}},
+		},
+	})
+
+	resp := app.queryIssueOccurrences(context.Background(), ds, "loki", "my-app", "", wantFP, time.Unix(0, 0), time.Unix(3600, 0))
+
+	if len(resp.Occurrences) != 1 {
+		t.Fatalf("got %d occurrences, want 1: %+v", len(resp.Occurrences), resp.Occurrences)
+	}
+	o := resp.Occurrences[0]
+	if o.TraceID != "body-trace-1" {
+		t.Errorf("traceId = %q, want body-trace-1 (from JSON body)", o.TraceID)
+	}
+	// Structured metadata + scalar body fields both surface as attributes.
+	if o.Attributes["k8s_node_name"] != "node-7" {
+		t.Errorf("attributes missing structured-metadata field: %+v", o.Attributes)
+	}
+	if o.Attributes["http_route"] != "/api/decorator" || o.Attributes["http_status"] != "502" || o.Attributes["logger"] != "decorator" {
+		t.Errorf("attributes missing app-added body fields: %+v", o.Attributes)
+	}
+	for _, banned := range []string{"message", "level", "traceId"} {
+		if _, ok := o.Attributes[banned]; ok {
+			t.Errorf("attributes must not include modeled body key %q: %+v", banned, o.Attributes)
+		}
+	}
+}
+
 func TestQueryIssueOccurrencesPlainShapeFiltersNoise(t *testing.T) {
 	wantFP := fingerprint.Compute(fingerprint.Event{Value: "panic: runtime error"}).Value
 
 	app, ds := occTestApp(t, map[string][]occLine{
 		keyPlain: {
-			{TimeMs: 8000, Line: "panic: runtime error", Labels: map[string]string{"k8s_pod_name": "p1", "detected_level": "error"}},
+			{TimeMs: 8000, Line: "panic: runtime error", Labels: map[string]string{"k8s_pod_name": "p1", "detected_level": "error", "trace_id": "plain-trace-1"}},
 			// logback bootstrap noise — must be dropped even before fingerprinting.
 			{TimeMs: 8500, Line: "12:00:00,000 |-INFO in ch.qos.logback.classic.LoggerContext - hello", Labels: map[string]string{"k8s_pod_name": "p1"}},
 			// Different message.
@@ -207,6 +263,9 @@ func TestQueryIssueOccurrencesPlainShapeFiltersNoise(t *testing.T) {
 	o := resp.Occurrences[0]
 	if o.Message != "panic: runtime error" || o.Pod != "p1" || o.Level != "error" {
 		t.Errorf("plain extraction wrong: %+v", o)
+	}
+	if o.TraceID != "plain-trace-1" {
+		t.Errorf("traceId = %q, want plain-trace-1 (best-effort from labels)", o.TraceID)
 	}
 	if o.Stacktrace != "" {
 		t.Errorf("plain occurrence should have no stacktrace, got %q", o.Stacktrace)

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -694,6 +694,16 @@ export interface IssueOccurrence {
   version?: string;
   /** Exception type (semconv shape only). */
   type?: string;
+  /** Distributed-trace correlation ID — deep-links this line to its full trace. */
+  traceId?: string;
+  /** Span ID within the correlated trace (best-effort). */
+  spanId?: string;
+  /**
+   * Remaining structured-metadata / body fields the line carries (k8s attrs,
+   * logger, http.route/status, app-added fields) minus the modeled ones above.
+   * Absent when the line adds no extra context.
+   */
+  attributes?: Record<string, string>;
 }
 
 /** Aggregate blast radius across the returned occurrences (sessions ↔ pods). */

--- a/src/pages/tabs/frontend/components/ExceptionDrawer.test.tsx
+++ b/src/pages/tabs/frontend/components/ExceptionDrawer.test.tsx
@@ -308,6 +308,9 @@ describe('server issues (#84)', () => {
         stacktrace: 'at Foo.bar(Foo.java:10)',
         version: '1.4.2',
         type: 'ConnectException',
+        traceId: 'abc123def456trace',
+        spanId: 'span-9',
+        attributes: { k8s_container_name: 'main', logger: 'com.example.Db' },
       },
       {
         timeMs: 1751536700000,
@@ -361,6 +364,60 @@ describe('server issues (#84)', () => {
     expect(screen.getAllByText('2 pods').length).toBeGreaterThan(0);
     // Feedback is a browser-only fetch — never called for server issues.
     expect(getFeedback).not.toHaveBeenCalled();
+  });
+
+  it('deep-links the occurrence to its exact trace (footer + context)', async () => {
+    getIssueOccurrences.mockResolvedValue(serverResponse);
+    renderServerDrawer();
+    await screen.findByText(/^2 occurrences$/);
+
+    // Footer "View this trace" link points at the Tempo datasource with the
+    // occurrence's trace ID as a traceql query.
+    const traceLink = screen.getByRole('link', { name: /View this trace/ });
+    const href = traceLink.getAttribute('href')!;
+    const left = JSON.parse(new URL(href, 'http://grafana.local').searchParams.get('left')!);
+    expect(left.datasource).toBe('tempo-uid');
+    expect(left.queries[0].queryType).toBe('traceql');
+    expect(left.queries[0].query).toBe('abc123def456trace');
+
+    // The same trace is linked from the occurrence-context meta list.
+    fireEvent.click(screen.getByRole('button', { name: /Occurrence context/ }));
+    expect(await screen.findByText(/Trace:/)).toBeInTheDocument();
+  });
+
+  it('renders the structured-metadata attributes in the occurrence context', async () => {
+    getIssueOccurrences.mockResolvedValue(serverResponse);
+    renderServerDrawer();
+    await screen.findByText(/^2 occurrences$/);
+
+    fireEvent.click(screen.getByRole('button', { name: /Occurrence context/ }));
+    expect(await screen.findByText(/k8s_container_name:/)).toBeInTheDocument();
+    expect(screen.getByText('main')).toBeInTheDocument();
+    expect(screen.getByText(/logger:/)).toBeInTheDocument();
+    expect(screen.getByText('com.example.Db')).toBeInTheDocument();
+  });
+
+  it('shows the limited-detail hint for json/plaintext shapes, linking the backend-exceptions guide', async () => {
+    getIssueOccurrences.mockResolvedValue({
+      fingerprint: 'v1:server1',
+      shape: 'json',
+      occurrences: [{ timeMs: 1751536800000, pod: 'app-abc', level: 'warn', message: 'Failed to fetch decorator' }],
+      stats: { total: 1, pods: 1, versions: [] },
+    });
+    renderServerDrawer();
+    await screen.findByText(/^1 occurrence$/);
+
+    expect(screen.getByText('Limited detail')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /Backend exceptions as issues/ });
+    expect(link).toHaveAttribute('href', 'https://doc.nais.io/observability/apm/how-to/backend-exceptions-as-issues/');
+  });
+
+  it('does not show the limited-detail hint for the otlp (semconv) shape', async () => {
+    getIssueOccurrences.mockResolvedValue(serverResponse);
+    renderServerDrawer();
+    await screen.findByText(/^2 occurrences$/);
+
+    expect(screen.queryByText('Limited detail')).not.toBeInTheDocument();
   });
 
   it('surfaces an empty-result message when no occurrences match', async () => {

--- a/src/pages/tabs/frontend/components/ExceptionDrawer.tsx
+++ b/src/pages/tabs/frontend/components/ExceptionDrawer.tsx
@@ -36,7 +36,7 @@ import { sanitizeLabelValue } from '../../../../utils/sanitize';
 import { apmDocs, frontendDocs } from '../../../../utils/docsLinks';
 import { usePluginLabelOverrides, usePluginDatasources } from '../../../../utils/datasources';
 import { useTimeRange } from '../../../../utils/timeRange';
-import { buildExceptionTracesExploreUrl } from '../../../../utils/explore';
+import { buildExceptionTracesExploreUrl, buildTraceExploreUrl } from '../../../../utils/explore';
 import { StackTraceView, isConsoleCaptureValue } from './StackTraceView';
 import { stackLooksMinified, firstScriptUrl } from '../frames';
 import { useIssueOccurrences, msToNs, ParsedException } from '../useIssueOccurrences';
@@ -156,7 +156,7 @@ export function ExceptionDrawer({
 
   // The two data paths (browser hash→Loki, server occurrences endpoint) are
   // abstracted behind this one hook; both resolve to occurrences + stats (#84).
-  const { loading, error, occurrences, stats } = useIssueOccurrences({
+  const { loading, error, occurrences, stats, shape } = useIssueOccurrences({
     source,
     hashes,
     issueId,
@@ -402,6 +402,17 @@ export function ExceptionDrawer({
           to: 'now',
         })
       : undefined;
+  // Deep-link to the *exact* trace this occurrence correlates to (#84 follow-up):
+  // the thin log line lacks spans / http / db / timing — the trace carries them.
+  // The selected time range is guaranteed to contain the occurrence, so it's the
+  // safe lookup window for the trace ID.
+  const occurrenceTraceUrl =
+    isServer && ds.tracesUid && exception?.traceId
+      ? buildTraceExploreUrl(ds.tracesUid, exception.traceId, { from: String(fromMs), to: String(toMs) })
+      : undefined;
+  // Shape (b)/(c) lines were logged as a message, not a throwable — no stack or
+  // type. Surface a non-alarming hint pointing at the backend-exceptions guide.
+  const showThinShapeHint = isServer && (shape === 'json' || shape === 'plaintext');
 
   // Minified-stack detection (#60): a heuristic over the rendered stack, plus
   // the candidate bundle URL the source-map doctor can probe. Both memoized on
@@ -493,6 +504,20 @@ export function ExceptionDrawer({
               </div>
             )}
 
+            {showThinShapeHint && (
+              <Alert severity="info" title="Limited detail">
+                <div className={styles.thinShapeHint}>
+                  <span>
+                    This was logged as a message, not an exception, so there is no stack trace or type. Log with the
+                    throwable to get full stack traces.
+                  </span>
+                  <TextLink href={apmDocs.backendExceptions()} external variant="bodySmall">
+                    Backend exceptions as issues
+                  </TextLink>
+                </div>
+              </Alert>
+            )}
+
             {exception.stacktrace && (
               <div className={styles.section}>
                 <h4 className={styles.sectionTitle}>
@@ -579,6 +604,16 @@ export function ExceptionDrawer({
                             <MetaItem label="Pod" value={exception.pod} icon="cube" />
                           )}
                           <MetaItem label="Timestamp" value={exception.timestamp} icon="clock-nine" />
+                          <MetaItem
+                            label="Trace"
+                            value={exception.traceId ? `${exception.traceId.slice(0, 16)}…` : undefined}
+                            link={occurrenceTraceUrl}
+                            icon="gf-traces"
+                          />
+                          {exception.attributes &&
+                            Object.entries(exception.attributes)
+                              .sort(([a], [b]) => a.localeCompare(b))
+                              .map(([k, v]) => <MetaItem key={k} label={k} value={v} icon="brackets-curly" />)}
                         </>
                       ) : (
                         <>
@@ -751,6 +786,19 @@ export function ExceptionDrawer({
                   <a href={serverLogsUrl} target="_blank" rel="noopener noreferrer" className={styles.footerLink}>
                     <Icon name="file-alt" /> View Raw Loki Log
                   </a>
+                  {occurrenceTraceUrl && (
+                    <>
+                      <span className={styles.footerDivider}>|</span>
+                      <a
+                        href={occurrenceTraceUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={styles.footerLink}
+                      >
+                        <Icon name="gf-traces" /> View this trace
+                      </a>
+                    </>
+                  )}
                   {serverTracesUrl && (
                     <>
                       <span className={styles.footerDivider}>|</span>
@@ -1321,6 +1369,12 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: flex;
     flex-direction: column;
     gap: ${theme.spacing(1)};
+    font-size: ${theme.typography.bodySmall.fontSize};
+  `,
+  thinShapeHint: css`
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacing(0.5)};
     font-size: ${theme.typography.bodySmall.fontSize};
   `,
   minifiedActions: css`

--- a/src/pages/tabs/frontend/useIssueOccurrences.ts
+++ b/src/pages/tabs/frontend/useIssueOccurrences.ts
@@ -40,6 +40,11 @@ export interface ParsedException {
   // Server-issue fields (#84):
   pod?: string;
   level?: string;
+  /** Distributed-trace correlation ID — deep-links the line to its full trace. */
+  traceId?: string;
+  spanId?: string;
+  /** Remaining structured-metadata / body fields the line carries (server issues). */
+  attributes?: Record<string, string>;
 }
 
 /**
@@ -82,6 +87,8 @@ export interface UseIssueOccurrencesResult {
   occurrences: ParsedException[];
   stats: AggregatedStats | null;
   truncated?: boolean;
+  /** Server-log shape the matched lines came from (server issues only). */
+  shape?: 'otlp' | 'json' | 'plaintext';
 }
 
 /**
@@ -103,6 +110,7 @@ export function useIssueOccurrences(opts: UseIssueOccurrencesOptions): UseIssueO
   const [occurrences, setOccurrences] = useState<ParsedException[]>([]);
   const [stats, setStats] = useState<AggregatedStats | null>(null);
   const [truncated, setTruncated] = useState<boolean | undefined>(undefined);
+  const [shape, setShape] = useState<'otlp' | 'json' | 'plaintext' | undefined>(undefined);
 
   // Stable key so the browser effect doesn't refire on array identity.
   const hashesKey = hashes.map(sanitizeLabelValue).join('|');
@@ -139,8 +147,12 @@ export function useIssueOccurrences(opts: UseIssueOccurrencesOptions): UseIssueO
           appVersion: o.version,
           pod: o.pod,
           level: o.level,
+          traceId: o.traceId,
+          spanId: o.spanId,
+          attributes: o.attributes,
         }));
         setOccurrences(occ);
+        setShape(res.shape);
         setStats({
           uniqueUsers: 0,
           uniqueSessions: res.stats.pods,
@@ -317,5 +329,5 @@ export function useIssueOccurrences(opts: UseIssueOccurrencesOptions): UseIssueO
     fl.serviceName,
   ]);
 
-  return { loading, error, source, occurrences, stats, truncated };
+  return { loading, error, source, occurrences, stats, truncated, shape };
 }

--- a/src/utils/docsLinks.test.ts
+++ b/src/utils/docsLinks.test.ts
@@ -40,6 +40,9 @@ describe('apmDocs builders', () => {
     expect(apmDocs.collectUserFeedback()).toBe('https://doc.nais.io/observability/apm/how-to/collect-user-feedback/');
     expect(apmDocs.databaseQueries()).toBe('https://doc.nais.io/observability/apm/how-to/database-queries/');
     expect(apmDocs.logPatterns()).toBe('https://doc.nais.io/observability/apm/how-to/log-patterns/');
+    expect(apmDocs.backendExceptions()).toBe(
+      'https://doc.nais.io/observability/apm/how-to/backend-exceptions-as-issues/'
+    );
     expect(apmDocs.apmClientApi()).toBe('https://doc.nais.io/observability/apm/reference/apm-client-api/');
     expect(apmDocs.issuesModel()).toBe('https://doc.nais.io/observability/apm/reference/issues-model/');
     expect(apmDocs.urlContract()).toBe('https://doc.nais.io/observability/apm/reference/url-contract/');

--- a/src/utils/docsLinks.ts
+++ b/src/utils/docsLinks.ts
@@ -49,6 +49,7 @@ export const apmDocs = {
   collectUserFeedback: () => docsUrl(`${APM}/how-to/collect-user-feedback`),
   databaseQueries: () => docsUrl(`${APM}/how-to/database-queries`),
   logPatterns: () => docsUrl(`${APM}/how-to/log-patterns`),
+  backendExceptions: () => docsUrl(`${APM}/how-to/backend-exceptions-as-issues`),
   // Reference
   apmClientApi: () => docsUrl(`${APM}/reference/apm-client-api`),
   issuesModel: () => docsUrl(`${APM}/reference/issues-model`),

--- a/src/utils/explore.test.ts
+++ b/src/utils/explore.test.ts
@@ -7,6 +7,7 @@ import {
   buildMetricsDrilldownUrl,
   buildTracesDrilldownUrl,
   buildExceptionTracesExploreUrl,
+  buildTraceExploreUrl,
 } from './explore';
 
 /** Parse the `left` param from a Grafana Explore URL */
@@ -50,6 +51,23 @@ describe('buildExploreUrl', () => {
     });
     const left = parseLeft(url);
     expect(left.range.from).toBe('now-6h');
+  });
+});
+
+describe('buildTraceExploreUrl', () => {
+  it('opens a single trace by ID via a traceql query on the Tempo datasource', () => {
+    const url = buildTraceExploreUrl('tempo-uid', 'abc123def456');
+    const left = parseLeft(url);
+    expect(left.datasource).toBe('tempo-uid');
+    expect(left.queries[0].queryType).toBe('traceql');
+    expect(left.queries[0].query).toBe('abc123def456');
+  });
+
+  it('uses the provided lookup window when both bounds are given', () => {
+    const url = buildTraceExploreUrl('tempo-uid', 'abc123', { from: '1700000000000', to: '1700003600000' });
+    const left = parseLeft(url);
+    expect(left.range.from).toBe('1700000000000');
+    expect(left.range.to).toBe('1700003600000');
   });
 });
 

--- a/src/utils/explore.ts
+++ b/src/utils/explore.ts
@@ -46,6 +46,25 @@ export function buildExceptionTracesExploreUrl(
   });
 }
 
+/**
+ * Explore URL that opens one specific trace by its ID in Tempo. Grafana's Tempo
+ * datasource resolves a bare trace ID passed as a `traceql` query to a single
+ * trace lookup — the same contract the exemplar "View trace" links use
+ * (`query: '${__value.raw}', queryType: 'traceql'`). This is the jump from a
+ * thin backend log line to the full trace (spans, http/db attributes, timing).
+ */
+export function buildTraceExploreUrl(
+  tempoUid: string,
+  traceId: string,
+  options?: { from?: string; to?: string }
+): string {
+  return buildExploreUrl({
+    datasourceUid: tempoUid,
+    queries: [{ refId: 'A', queryType: 'traceql', query: escapeQueryString(traceId) }],
+    range: options?.from && options?.to ? { from: options.from, to: options.to } : undefined,
+  });
+}
+
 export function buildTempoExploreUrl(
   tempoUid: string,
   serviceName: string,


### PR DESCRIPTION
## Why

Backend (server-log) exceptions of shape **b** (JSON message-only) and **c** (plaintext) carry no throwable, so the occurrence drawer was nearly empty — the motivating case being a bare `log.warn("Failed to fetch decorator…")`. But the raw Loki line almost always carries more (trace correlation, k8s attrs, logger, http fields). This surfaces that context.

## What

**1. Trace deep-link (priority).** Each occurrence now captures `trace_id` / `span_id`:
- Shape a (OTLP): read from structured metadata (`trace_id` / `span_id` labels).
- Shape b (JSON): structured metadata first, else a JSON-body fallback (`trace_id` / `traceId` / `traceID`).
- Shape c (plaintext): best-effort from structured metadata.

When an occurrence has a `traceId`, the drawer deep-links the **exact** trace via a new `buildTraceExploreUrl(tempoUid, traceId)` — an Explore URL with `queryType: 'traceql'` and the trace ID as the query, the same single-trace-lookup contract the existing exemplar "View trace" links use. Rendered as a footer **"View this trace"** link and a **Trace** row in the occurrence context. This is the jump from a thin log line to the full trace (spans, http/db attributes, timing).

**2. Full structured-metadata field set.** The occurrence handler now returns the remaining line fields (k8s container/node, logger, http.route/status, app-added structured fields) as `attributes?: Record<string,string>`, excluding everything already modeled (message/level/pod/version/type/trace_id/span_id), Loki-internal `__*__` labels, and stream-identity labels (service/env/kind). For JSON lines the app's own scalar body fields are merged in too. Rendered in the existing "Occurrence context" collapsible.

**3. Shape-b/c hint.** When `shape` is `json` or `plaintext`, a non-alarming *"Limited detail — logged as a message, not an exception…"* info hint links the `backend-exceptions-as-issues` how-to, reusing the existing `apmDocs` docs-link pattern.

## Backward compatibility
Shape (a) drawers are unchanged; every new field is optional and degrades to nothing rendered when absent — no empty sections.

## Tests
- Go: extended `occurrences_test.go` — trace_id/span_id + attributes extraction (with modeled/internal keys excluded) across semconv, JSON (trace_id from body + app fields), and plaintext shapes.
- Frontend: `explore.test.ts` (trace URL builder), `docsLinks.test.ts` (new slug), `ExceptionDrawer.test.tsx` (trace deep-link footer + context, attributes render, hint gated on shape).
- Full suite green: `go test ./pkg/...`, `pnpm test:ci` (827 tests), typecheck, eslint, prettier, golangci-lint, plugin validate — all via the repo pre-commit `mise run all`.