### PR TITLE
feat(database): Phase 1 redesign — drop per-host, add N+1 ratio, surface pool contention

### DIFF
--- a/pkg/plugin/otelconfig/otelconfig.go
+++ b/pkg/plugin/otelconfig/otelconfig.go
@@ -244,6 +244,7 @@ type DBPoolMetrics struct {
 	OtelDBIdle    string // db_client_connections_idle_min — gauge (legacy, unused)
 	OtelDBMax     string // db_client_connections_max — gauge
 	OtelDBPending string // db_client_connections_pending_requests — gauge
+	OtelDBTimeout string // db_client_connections_timeouts_total — counter (pool exhaustion)
 
 	PoolLabel     string // "pool" — pool name on hikaricp_* gauges
 	PoolNameLabel string // "pool_name" — pool name on db_client_connections_* gauges
@@ -506,6 +507,7 @@ func Default() Config {
 				OtelDBIdle:    "db_client_connections_idle_min",
 				OtelDBMax:     "db_client_connections_max",
 				OtelDBPending: "db_client_connections_pending_requests",
+				OtelDBTimeout: "db_client_connections_timeouts_total",
 				PoolLabel:     "pool",
 				PoolNameLabel: "pool_name",
 				StateLabel:    "state",

--- a/pkg/plugin/runtime.go
+++ b/pkg/plugin/runtime.go
@@ -549,6 +549,7 @@ func (a *App) queryDBPoolRuntime(
 		// names need the sum.
 		{"otMax", fmt.Sprintf(`sum by (%s) (max_over_time(%s{%s}%s))`, rt.PoolNameLabel, rt.OtelDBMax, svcFilter, lookback)},
 		{"otPending", fmt.Sprintf(`sum by (%s) (avg_over_time(%s{%s}%s))`, rt.PoolNameLabel, rt.OtelDBPending, svcFilter, lookback)},
+		{"otTimeout", fmt.Sprintf(`sum by (%s) (rate(%s{%s}%s))`, rt.PoolNameLabel, rt.OtelDBTimeout, svcFilter, lookback)},
 	}
 
 	var wg sync.WaitGroup
@@ -624,6 +625,9 @@ func (a *App) queryDBPoolRuntime(
 	}
 	for _, r := range resultMap["otPending"] {
 		getOtelPool(r.Metric[rt.PoolNameLabel]).Pending = roundTo(safeFloat(r.Value.Float()), 1)
+	}
+	for _, r := range resultMap["otTimeout"] {
+		getOtelPool(r.Metric[rt.PoolNameLabel]).TimeoutRate = roundTo(safeFloat(r.Value.Float()), 4)
 	}
 	for name, p := range otelMap {
 		if _, ok := poolMap[name]; !ok {

--- a/pkg/plugin/runtime_test.go
+++ b/pkg/plugin/runtime_test.go
@@ -106,6 +106,7 @@ func TestQueryDBPoolRuntime(t *testing.T) {
 				usageQ(dp, dp.StateIdle): {poolResult(dp.PoolNameLabel, "UniversalConnectionPool(42)-pod-a", "6")},
 				dp.OtelDBMax:             {poolResult(dp.PoolNameLabel, "UniversalConnectionPool(42)-pod-a", "20")},
 				dp.OtelDBPending:         {poolResult(dp.PoolNameLabel, "UniversalConnectionPool(42)-pod-a", "1")},
+				dp.OtelDBTimeout:         {poolResult(dp.PoolNameLabel, "UniversalConnectionPool(42)-pod-a", "0.02")},
 			},
 			assert: func(t *testing.T, pools map[string]queries.DBPool) {
 				if len(pools) != 1 {
@@ -117,6 +118,10 @@ func TestQueryDBPoolRuntime(t *testing.T) {
 				}
 				if p.Active != 4 || p.Idle != 6 || p.Max != 20 || p.Pending != 1 {
 					t.Errorf("active/idle/max/pending = %v/%v/%v/%v, want 4/6/20/1", p.Active, p.Idle, p.Max, p.Pending)
+				}
+				// db_client_connections_timeouts_total → TimeoutRate (pool exhaustion).
+				if p.TimeoutRate != 0.02 {
+					t.Errorf("timeoutRate = %v, want 0.02", p.TimeoutRate)
 				}
 				if p.Utilization != 20 {
 					t.Errorf("utilization = %v, want 20", p.Utilization)

--- a/src/pages/tabs/DatabaseTab.tsx
+++ b/src/pages/tabs/DatabaseTab.tsx
@@ -147,8 +147,8 @@ export function DatabaseTab({
   // Follow header refreshes of relative ranges without rebuilding the scene.
   useSceneTimeSync(scene, fromMs, toMs);
   const sceneKey = `${ds.metricsUid}|${callsMetric}|${durationBucket}|${environment ?? ''}|${hasDbSpans}|${hasDbPool}`;
-  // RED row + host table ≈ 490px, acquisition row ≈ 210px.
-  const sceneMinHeight = (hasDbSpans ? 490 : 0) + (hasDbPool ? 210 : 0);
+  // Queries-per-request stat (120) + RED row (220) ≈ 360px; acquisition row ≈ 210px.
+  const sceneMinHeight = (hasDbSpans ? 360 : 0) + (hasDbPool ? 210 : 0);
 
   const onViewDbTraces = onViewTraces
     ? (spanName: string, status?: string) => onViewTraces(spanName, status, otel.spanKinds.client)

--- a/src/pages/tabs/database/ConnectionPoolSection.test.tsx
+++ b/src/pages/tabs/database/ConnectionPoolSection.test.tsx
@@ -37,6 +37,60 @@ describe('ConnectionPoolSection', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  // --- Pool-contention signals (PRD #119 §4.4) ---
+
+  it('surfaces pool-config advice when contention signals fire (pending / timeouts)', () => {
+    // HikariPool-2 in the fixture has pending 1.2 and timeoutRate 0.05.
+    render(<ConnectionPoolSection dbPool={dbPool} />);
+    const note = screen.getByRole('note', { name: 'Connection pool configuration advice' });
+    expect(note).toBeInTheDocument();
+    expect(note.textContent).toMatch(/timeouts/i);
+    expect(note.textContent).toMatch(/waiting for a connection/i);
+    expect(note.textContent).toMatch(/maximumPoolSize/);
+  });
+
+  it('flags high saturation (> 90%) as a pool-config signal', () => {
+    const saturated: DBPoolRuntime = {
+      status: 'detected',
+      pools: [
+        {
+          name: 'HikariPool-1',
+          type: 'hikari',
+          active: 19,
+          idle: 1,
+          max: 20,
+          pending: 0,
+          timeoutRate: 0,
+          utilization: 95,
+        },
+      ],
+    };
+    render(<ConnectionPoolSection dbPool={saturated} />);
+    expect(screen.getByRole('note', { name: 'Connection pool configuration advice' }).textContent).toMatch(
+      /saturation/i
+    );
+  });
+
+  it('renders no advice note when every pool is healthy', () => {
+    const healthy: DBPoolRuntime = {
+      status: 'detected',
+      pools: [
+        {
+          name: 'HikariPool-1',
+          type: 'hikari',
+          active: 2,
+          idle: 8,
+          max: 10,
+          pending: 0,
+          timeoutRate: 0,
+          utilization: 20,
+        },
+      ],
+    };
+    render(<ConnectionPoolSection dbPool={healthy} />);
+    expect(screen.queryByRole('note', { name: 'Connection pool configuration advice' })).not.toBeInTheDocument();
+  });
+
   // --- Accessibility (WCAG 1.3.1 / 1.4.1) ---
 
   it('names the table and gives the colour-coded utilization bar a text equivalent', () => {

--- a/src/pages/tabs/database/ConnectionPoolSection.tsx
+++ b/src/pages/tabs/database/ConnectionPoolSection.tsx
@@ -10,8 +10,38 @@ interface ConnectionPoolSectionProps {
 }
 
 const POOL_HEALTH_NOTE =
-  'Point-in-time pool gauges (active/idle/max/pending/timeouts), averaged over the selected time range. ' +
-  'See the "Connection Acquisition" charts above for wait-time and create-time distributions.';
+  'Pool-configuration signals, averaged over the selected time range. Saturation (active ÷ max) shows how close the ' +
+  'pool runs to its ceiling; Pending is threads blocked waiting for a connection; Timeouts/s is connection-acquisition ' +
+  'exhaustion. These map directly to your pool config (maximumPoolSize / connectionTimeout). See the "Connection ' +
+  'Acquisition" charts above for wait-time and create-time distributions.';
+
+/**
+ * Derives the pool-contention signals from the snapshot and turns them into
+ * short, pool-config-framed remediation lines. Empty when every pool is
+ * comfortably below its limits — the section then renders just the table.
+ */
+function contentionAdvice(pools: DBPoolRuntime['pools']): string[] {
+  const advice: string[] = [];
+  if (pools.some((p) => p.timeoutRate > 0)) {
+    advice.push(
+      'Connection-acquisition timeouts are firing — the pool is exhausted. Raise maximumPoolSize, or shorten how ' +
+        'long connections are held (smaller transactions, faster queries).'
+    );
+  }
+  if (pools.some((p) => p.pending > 0)) {
+    advice.push(
+      'Threads are queued waiting for a connection (Pending > 0). The pool is a bottleneck under load — raise ' +
+        'maximumPoolSize or reduce connection hold time.'
+    );
+  }
+  if (pools.some((p) => p.utilization > 90)) {
+    advice.push(
+      'A pool is running above 90% saturation (active ÷ max). It has little headroom for traffic spikes — consider a ' +
+        'larger maximumPoolSize.'
+    );
+  }
+  return advice;
+}
 
 /**
  * Connection pool health — elevated from RuntimeTab's DBPoolCard (issue #14).
@@ -27,6 +57,8 @@ export function ConnectionPoolSection({ dbPool }: ConnectionPoolSectionProps) {
   if (!dbPool.pools || dbPool.pools.length === 0) {
     return null;
   }
+
+  const advice = contentionAdvice(dbPool.pools);
 
   return (
     <div className={styles.section}>
@@ -45,9 +77,18 @@ export function ConnectionPoolSection({ dbPool }: ConnectionPoolSectionProps) {
             <th scope="col">Active</th>
             <th scope="col">Idle</th>
             <th scope="col">Max</th>
-            <th scope="col">Pending</th>
-            <th scope="col">Utilization</th>
-            <th scope="col">Timeouts/s</th>
+            <th scope="col" title="Threads waiting for a connection (db_client_connections_pending_requests)">
+              Pending
+            </th>
+            <th scope="col" title="Active ÷ max connections — how close the pool runs to its ceiling">
+              Saturation
+            </th>
+            <th
+              scope="col"
+              title="Connection-acquisition timeouts per second (db_client_connections_timeouts_total) — pool exhaustion"
+            >
+              Timeouts/s
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -73,6 +114,16 @@ export function ConnectionPoolSection({ dbPool }: ConnectionPoolSectionProps) {
           ))}
         </tbody>
       </table>
+      {advice.length > 0 && (
+        <div className={styles.advice} role="note" aria-label="Connection pool configuration advice">
+          <Icon name="exclamation-triangle" size="sm" />
+          <ul className={styles.adviceList}>
+            {advice.map((line) => (
+              <li key={line}>{line}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }
@@ -121,6 +172,29 @@ const getStyles = (theme: GrafanaTheme2) => ({
     &:hover {
       opacity: 1;
     }
+  `,
+  advice: css`
+    display: flex;
+    gap: ${theme.spacing(1)};
+    margin-top: ${theme.spacing(1)};
+    padding: ${theme.spacing(1)} ${theme.spacing(1.5)};
+    border-radius: ${theme.shape.radius.default};
+    background: ${theme.colors.warning.transparent};
+    border: 1px solid ${theme.colors.warning.borderTransparent};
+    color: ${theme.colors.text.primary};
+    font-size: ${theme.typography.bodySmall.fontSize};
+    svg {
+      color: ${theme.colors.warning.text};
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+  `,
+  adviceList: css`
+    margin: 0;
+    padding-left: ${theme.spacing(2)};
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacing(0.5)};
   `,
   warnCell: css`
     text-align: right;

--- a/src/pages/tabs/database/scene.test.ts
+++ b/src/pages/tabs/database/scene.test.ts
@@ -94,10 +94,12 @@ describe('buildDatabaseScene', () => {
     );
   });
 
-  it('omits the RED row and host table when hasDbSpans is false', () => {
+  it('omits the RED row and queries-per-request stat when hasDbSpans is false', () => {
     const scene = buildDatabaseScene({ ...defaultParams, hasDbSpans: false, hasDbPool: true });
     const serialized = JSON.stringify(scene!.state.body);
     expect(serialized).not.toContain('traces_spanmetrics_calls_total');
+    expect(serialized).not.toContain('Queries per request');
+    expect(serialized).not.toContain('SPAN_KIND_SERVER');
     expect(serialized).toContain('db_client_connections_wait_time_milliseconds_bucket');
   });
 
@@ -107,10 +109,37 @@ describe('buildDatabaseScene', () => {
     expect(serialized).toContain('traces_spanmetrics_calls_total');
   });
 
-  it('builds a per-host breakdown table grouped by db_system and server_address', () => {
+  it('does not build a per-host breakdown (removed in the #119 redesign)', () => {
     const scene = buildDatabaseScene(defaultParams);
     const serialized = JSON.stringify(scene!.state.body);
-    expect(serialized).toContain('sum by (db_system, server_address)');
+    expect(serialized).not.toContain('server_address');
+    expect(serialized).not.toContain('Per-host breakdown');
+  });
+
+  it('adds a queries-per-request ratio: db CLIENT spans divided by inbound SERVER spans', () => {
+    const scene = buildDatabaseScene(defaultParams);
+    const serialized = JSON.stringify(scene!.state.body);
+    expect(serialized).toContain('Queries per request');
+    // Denominator selects inbound SERVER spans (HTTP + gRPC).
+    expect(serialized).toContain('SPAN_KIND_SERVER');
+    // Numerator is the same CLIENT db-span rate the Rate panel sums.
+    expect(serialized).toMatch(
+      /sum\(rate\(traces_spanmetrics_calls_total\{[^}]*SPAN_KIND_CLIENT[^}]*\}\[\$__rate_interval\]\)\)/
+    );
+  });
+
+  it('guards the ratio against divide-by-zero so non-HTTP services read N/A instead of +Inf', () => {
+    const scene = buildDatabaseScene(defaultParams);
+    const serialized = JSON.stringify(scene!.state.body);
+    // `sum(db) / (sum(inbound) > 0)` — the `> 0` filter drops the series when a
+    // service has no inbound SERVER spans (batch jobs, pure Kafka consumers) or
+    // a zero request rate in-window, leaving the stat empty (rendered as N/A)
+    // rather than dividing by zero.
+    expect(serialized).toMatch(
+      /\/ \(sum\(rate\(traces_spanmetrics_calls_total\{[^}]*SPAN_KIND_SERVER[^}]*\}\[\$__rate_interval\]\)\) > 0\)/
+    );
+    // The stat surfaces the empty result as an explicit N/A rather than "No data".
+    expect(serialized).toContain('N/A');
   });
 
   it('omits the connection-acquisition panels when hasDbPool is false (the default)', () => {

--- a/src/pages/tabs/database/scene.ts
+++ b/src/pages/tabs/database/scene.ts
@@ -7,7 +7,7 @@ import {
   EmbeddedScene,
   behaviors,
 } from '@grafana/scenes';
-import { DashboardCursorSync } from '@grafana/schema';
+import { DashboardCursorSync, ThresholdsMode } from '@grafana/schema';
 import { otel } from '../../../otelconfig';
 import { sanitizeLabelValue, escapeQueryString } from '../../../utils/sanitize';
 import { buildExploreUrl } from '../../../utils/explore';
@@ -28,8 +28,8 @@ export interface BuildDatabaseSceneParams {
   deploymentEnvLabel?: string;
   /** Whether the backend's /endpoints response has database operations for this
    * service (EndpointGroups.database non-empty). Gates the span-metrics-backed
-   * rows (RED + per-host) so a pool-only service doesn't render three empty
-   * panels. Defaults to true. */
+   * overview rows (queries-per-request ratio + RED) so a pool-only service
+   * doesn't render empty panels. Defaults to true. */
   hasDbSpans?: boolean;
   /** Whether RuntimeResponse.dbPool was detected for this service (RuntimeTab's
    * DBPoolRuntime). Gates the connection-acquisition-time panels — see notes
@@ -54,8 +54,9 @@ export function buildDbTracesExploreUrl(tracesUid: string, service: string, name
 }
 
 /**
- * Builds the Database tab's RED time-series panels (Rate / Errors / P95
- * Duration, broken down by db.system) plus a per-host breakdown table.
+ * Builds the Database tab's overview panels — a queries-per-request ratio
+ * (the always-on N+1 smell) plus the RED time-series (Rate / Errors / P95
+ * Duration, broken down by db.system).
  *
  * Data source: the same auto-detected span-metrics calls/duration metrics
  * used everywhere else in the plugin (see utils/capabilities.ts), filtered
@@ -69,13 +70,23 @@ export function buildDbTracesExploreUrl(tracesUid: string, service: string, name
  * major db systems: pdl/pdl-api (mongodb, ~112 calls/s), pensjon-person/
  * pensjon-representasjon (oracle, ~2 calls/s), teamforeldrepenger/
  * fpinntektsmelding (postgresql, ~8.6 calls/s). Rate, duration P95,
- * per-host, and (zero-filled) error panels all return data for all three.
+ * and (zero-filled) error panels all return data for all three.
  *
- * Per-host breakdown relies on the `server_address` label, which spanmetrics
- * pipelines populate from the client span's `server.address` attribute (used
- * elsewhere for dependency host resolution — see servicemap.go). Not every
- * database client library populates this attribute, so the panel may be
- * empty for some services; that's a genuine "no data" rather than a query bug.
+ * Queries-per-request ratio (per Database-tab redesign PRD, issue #119):
+ * database operations per inbound request. Numerator is the same outbound
+ * CLIENT db-span rate the Rate panel sums; denominator is the inbound
+ * SERVER-span rate for the service (covers HTTP *and* gRPC — a superset of
+ * the PRD's http_server_request_count). Kept on the tab's existing
+ * span-metrics source rather than the raw db_client_operation_/http_server_
+ * metric families so the label conventions (service_name/namespace/env) stay
+ * consistent with the RED panels. A `> 0` guard on the denominator drops the
+ * series when the service has no inbound requests (batch jobs, pure Kafka
+ * consumers) or its request rate is zero in-window, so the stat reads N/A
+ * instead of dividing by zero. A high value flags an N+1 pattern.
+ *
+ * (The per-host `server_address` breakdown was removed in the #119 redesign:
+ * "which database host served this" is a DBA/infra concern, not something an
+ * application developer acts on in their own code or config.)
  *
  * Connection acquisition time (`hasDbPool` gated): verified directly against
  * production Mimir (2026-07-04) that `db_client_connections_wait_time_milliseconds_bucket`
@@ -129,6 +140,9 @@ export function buildDatabaseScene(params: BuildDatabaseSceneParams): EmbeddedSc
   // criteria the backend uses to classify "database" endpoints (see
   // EndpointGroups.database in api/client.ts).
   const dbFilter = `${svcFilter}, ${otel.labels.spanKind}="${otel.spanKinds.client}", ${otel.labels.dbSystem}=~".+"`;
+  // Inbound requests: SERVER-kind spans for this service (HTTP + gRPC). Used as
+  // the denominator of the queries-per-request ratio.
+  const serverFilter = `${svcFilter}, ${otel.labels.spanKind}="${otel.spanKinds.server}"`;
   const panelDurationUnit = durationUnit === 's' ? 's' : 'ms';
 
   const rateQuery = new SceneQueryRunner({
@@ -178,14 +192,19 @@ export function buildDatabaseScene(params: BuildDatabaseSceneParams): EmbeddedSc
     ],
   });
 
-  const hostQuery = new SceneQueryRunner({
+  // Queries-per-request ratio — the always-on N+1 smell (PRD #119 §4.1).
+  // db operations ÷ inbound requests. The `> 0` guard on the denominator makes
+  // the expression empty (→ stat reads N/A) for services with no inbound
+  // SERVER spans, rather than producing +Inf from a divide-by-zero.
+  const ratioQuery = new SceneQueryRunner({
     datasource: { uid: metricsUid, type: 'prometheus' },
+    minInterval: '5m',
     queries: [
       {
         refId: 'A',
-        instant: true,
-        format: 'table',
-        expr: `sum by (${otel.labels.dbSystem}, ${otel.labels.serverAddress}) (rate(${callsMetric}{${dbFilter}}[$__rate_interval]))`,
+        expr:
+          `sum(rate(${callsMetric}{${dbFilter}}[$__rate_interval])) ` +
+          `/ (sum(rate(${callsMetric}{${serverFilter}}[$__rate_interval])) > 0)`,
       },
     ],
   });
@@ -251,6 +270,31 @@ export function buildDatabaseScene(params: BuildDatabaseSceneParams): EmbeddedSc
         ...(hasDbSpans
           ? [
               new SceneFlexItem({
+                height: 120,
+                width: 300,
+                body: PanelBuilders.stat()
+                  .setTitle('Queries per request')
+                  .setDescription(
+                    'Database operations per inbound request (outbound db CLIENT spans ÷ inbound SERVER spans). ' +
+                      'A high value is the classic N+1 smell — many small queries where a single JOIN or batch-fetch ' +
+                      'would do; use "View DB traces" above to inspect the offending requests. Reads N/A for services ' +
+                      'with no inbound requests (e.g. batch jobs or pure Kafka consumers).'
+                  )
+                  .setData(ratioQuery)
+                  .setUnit('none')
+                  .setDecimals(1)
+                  .setNoValue('N/A')
+                  .setThresholds({
+                    mode: ThresholdsMode.Absolute,
+                    steps: [
+                      { value: null as unknown as number, color: 'green' },
+                      { value: 20, color: 'orange' },
+                      { value: 50, color: 'red' },
+                    ],
+                  })
+                  .build(),
+              }),
+              new SceneFlexItem({
                 body: new SceneFlexLayout({
                   direction: 'row',
                   children: [
@@ -285,16 +329,6 @@ export function buildDatabaseScene(params: BuildDatabaseSceneParams): EmbeddedSc
                     }),
                   ],
                 }),
-              }),
-              new SceneFlexItem({
-                height: 250,
-                body: PanelBuilders.table()
-                  .setTitle('Per-host breakdown')
-                  .setDescription(
-                    'Call rate by db.system and server.address. Empty when the database client does not populate the server.address attribute.'
-                  )
-                  .setData(hostQuery)
-                  .build(),
               }),
             ]
           : []),


### PR DESCRIPTION
Implements **Phase 1** of the Database-tab redesign PRD (#119), reframing the tab around signals an **application developer** can act on in their own code/config — not infra/DBA shapes.

## What changed

### 1. Removed the per-host breakdown
`server_address` "which DB host served this" is a DBA/infra concern. Dropped the `hostQuery` and the "Per-host breakdown" table from `database/scene.ts`, updated the scene doc-comment, and recomputed `DatabaseTab.tsx`'s `sceneMinHeight`: was `RED row + host table ≈ 490px`, now `queries-per-request stat (120) + RED row (220) ≈ 360px` — no empty space left behind.

### 2. Added the queries-per-request ratio (always-on N+1 smell)
A compact stat panel in the overview area. Database operations per inbound request:

```promql
sum(rate(traces_spanmetrics_calls_total{<svc>, span_kind="SPAN_KIND_CLIENT", db_system=~".+"}[$__rate_interval]))
/ (sum(rate(traces_spanmetrics_calls_total{<svc>, span_kind="SPAN_KIND_SERVER"}[$__rate_interval])) > 0)
```

Kept on the tab's existing **span-metrics** source (rather than the raw `db_client_operation_*` / `http_server_*` families) so the label conventions (`service_name`/`service_namespace`/`k8s_cluster_name`) stay consistent with the RED panels. The numerator is the same CLIENT db-span rate the Rate panel sums; the denominator is inbound **SERVER** spans, which covers HTTP **and** gRPC — a superset of the PRD's `http_server_request_count`.

**Non-HTTP services handled gracefully:** the `> 0` guard on the denominator drops the series when a service has no inbound SERVER spans (batch jobs, pure Kafka consumers) or a zero request rate in-window, so the stat reads **N/A** instead of producing `+Inf` from a divide-by-zero. Thresholds flag high values (orange ≥ 20, red ≥ 50) and the panel description explains the N+1 remediation and points at "View DB traces".

### 3. Surfaced connection-pool contention as pool-config signals
`ConnectionPoolSection` now frames pending / timeouts / saturation as **pool-config** signals and renders a short, actionable advisory (raise `maximumPoolSize` / adjust `connectionTimeout`) when any pool shows queued threads, acquisition timeouts, or > 90% saturation. Wired `db_client_connections_timeouts_total` into the OTel pool path in the backend (`runtime.go` + `otelconfig.go`) so timeouts surface for UCP/OTel pools too, not just HikariCP. The Oracle-UCP / Mongo-driver "not instrumented" messaging is unchanged.

## Tests
- Extended `scene.test.ts`: ratio present, CLIENT÷SERVER shape, divide-by-zero guard / N/A fallback, and per-host breakdown removed.
- Extended `ConnectionPoolSection.test.tsx`: advisory fires on pending/timeouts and on > 90% saturation; no note when healthy.
- Extended `runtime_test.go`: OTel timeout → `TimeoutRate`.
- `mise run all` green (go test, `pnpm test:ci` 826 tests, tsc, eslint, prettier, golangci-lint, plugin validate).

## Deferred (per PRD phasing)
- **Phase 2** — Top queries (Tempo-sourced, normalized), needs the backend Tempo-query + cache plumbing.
- **Phase 3** — On-demand N+1 scan + per-system remediation hints.

Refs #119.