### PR TITLE
feat(database): on-demand N+1 query-pattern scan (#119 Phase 3)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -558,6 +558,53 @@ paths:
                         p95Ms: { type: number }
                         traceId: { type: string }
 
+  /services/{namespace}/{service}/database/nplusone:
+    get:
+      tags: [experimental]
+      summary: On-demand N+1 query-pattern scan (Tempo, bounded + cached).
+      description: >-
+        Scans a bounded, cached sample of this service's traces for N+1 query
+        patterns — the same normalized db.statement repeated many times within a
+        single request. Statements are normalized server-side (literals stripped)
+        before return; raw literals are never exposed. On-demand only (a "Scan
+        for N+1" action, not continuous); the window is clamped and both the
+        candidate-trace count and spans-per-trace are limited to bound Tempo cost.
+      parameters:
+        - { $ref: "#/components/parameters/namespacePath" }
+        - { $ref: "#/components/parameters/servicePath" }
+        - { $ref: "#/components/parameters/from" }
+        - { $ref: "#/components/parameters/to" }
+        - name: tracesUid
+          in: query
+          schema: { type: string, pattern: "^[a-zA-Z0-9_-]{1,64}$" }
+      responses:
+        "200":
+          description: N+1 findings.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  mode: { type: string, enum: [traceql, unavailable] }
+                  scannedTraces: { type: integer }
+                  truncated: { type: boolean }
+                  windowSeconds: { type: integer }
+                  threshold: { type: integer }
+                  note: { type: string }
+                  findings:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        statement: { type: string }
+                        dbSystem: { type: string }
+                        table: { type: string }
+                        repeatCount: { type: integer }
+                        endpoint: { type: string }
+                        totalDbSpans: { type: integer }
+                        traceId: { type: string }
+                        remediation: { type: string }
+
   /services/{namespace}/{service}/scorecard:
     get:
       tags: [experimental]

--- a/pkg/plugin/app.go
+++ b/pkg/plugin/app.go
@@ -402,6 +402,7 @@ func (a *App) routes() []appRoute {
 		{"/services/{namespace}/{service}/runtime", a.handleRuntime},
 		{"/services/{namespace}/{service}/custom-metrics", a.handleCustomMetrics},
 		{"/services/{namespace}/{service}/database/queries", a.handleDatabaseQueries},
+		{"/services/{namespace}/{service}/database/nplusone", a.handleDatabaseNPlusOne},
 		{"/services/{namespace}/{service}/scorecard", a.handleScorecard},
 		{"/services/{namespace}/{service}/alerts", a.handleServiceAlerts},
 		{"/jobs", a.handleJobs},

--- a/pkg/plugin/dbnplusone.go
+++ b/pkg/plugin/dbnplusone.go
@@ -1,0 +1,387 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+)
+
+// N+1 & query-pattern scan — Database tab Phase 3 (issue #119 §4.3).
+//
+// This is the "confirm" layer of the two-layer N+1 detection (§4.3): the
+// always-on queries-per-request ratio (Phase 1) flags N+1-prone endpoints; this
+// on-demand scan pins down the exact offender — "endpoint X ran «query» N× in
+// one request" — with a trace link and a per-system remediation hint.
+//
+// It reuses the Phase 2 plumbing wholesale: the bounded Tempo /api/search proxy
+// (searchDBSpans), the response parser's span-attribute extraction, the window
+// clamp, the SA-token/datasource-allowlist hardening, the response cache, and —
+// critically — the same server-side statement normalization (dbnormalize.go), so
+// raw literals never reach the UI (§6, PII-safe).
+//
+// Cost posture (§6): on-demand only (a "Scan for N+1" action, never a background
+// sweep), per-service, window clamped to ≤1h, candidate traces + spans-per-trace
+// both capped, a 25s timeout, and the whole result cached. Tempo unavailable →
+// a clean "unavailable" state, never a hang.
+
+const (
+	// nplusoneWindowCap bounds the TraceQL scan window (clamped to the most
+	// recent slice of this size). Matches the top-queries cap.
+	nplusoneWindowCap = time.Hour
+	// nplusoneRepeatThreshold is the per-trace duplicate-count that makes a
+	// normalized statement an N+1 finding: the same fingerprint issued at least
+	// this many times inside one request. Tunable (§9). The TraceQL scan pulls
+	// candidate traces at count() > repeat-1 (the natural floor — a trace cannot
+	// repeat one statement N times without having N db spans), then the exact
+	// per-statement grouping is confirmed here in Go.
+	nplusoneRepeatThreshold = 10
+	// nplusoneTraceLimit caps candidate traces scanned; nplusoneSpansPerSet caps
+	// DB spans pulled per trace (must exceed the repeat threshold so the grouping
+	// can see the duplicates). Together they bound Tempo cost.
+	nplusoneTraceLimit  = 100
+	nplusoneSpansPerSet = 100
+	// nplusoneMaxFindings caps the findings returned to the UI.
+	nplusoneMaxFindings = 50
+	// nplusoneTimeout bounds the single Tempo search call end-to-end.
+	nplusoneTimeout = 25 * time.Second
+)
+
+// NPlusOneFinding is one repeated-query offender inside a single request: the
+// normalized statement run RepeatCount times in the trace rooted at Endpoint.
+// Statement is always the normalized fingerprint (never a raw literal, §6).
+type NPlusOneFinding struct {
+	Statement string `json:"statement"`
+	DBSystem  string `json:"dbSystem"`
+	Table     string `json:"table,omitempty"`
+	// RepeatCount is how many times this normalized statement ran in the trace.
+	RepeatCount int `json:"repeatCount"`
+	// Endpoint is the root span / route the request entered through.
+	Endpoint string `json:"endpoint"`
+	// TotalDBSpans is the number of DB spans observed in the trace (a sample,
+	// capped at nplusoneSpansPerSet).
+	TotalDBSpans int `json:"totalDbSpans"`
+	// TraceID links to the offending trace.
+	TraceID string `json:"traceId"`
+	// Remediation is the per-system hint (JOIN/batch, MGET/pipeline, $in, …).
+	Remediation string `json:"remediation"`
+}
+
+// NPlusOneResponse is the /database/nplusone payload.
+type NPlusOneResponse struct {
+	// Mode is "traceql" when Tempo answered, else "unavailable".
+	Mode     string            `json:"mode"`
+	Findings []NPlusOneFinding `json:"findings"`
+	// ScannedTraces is the number of candidate traces the scan inspected.
+	ScannedTraces int `json:"scannedTraces"`
+	// Truncated is true when the candidate-trace limit was hit.
+	Truncated bool `json:"truncated"`
+	// WindowSeconds is the effective (possibly clamped) window queried.
+	WindowSeconds int `json:"windowSeconds"`
+	// Threshold is the per-trace repeat count that qualifies a finding.
+	Threshold int    `json:"threshold"`
+	Note      string `json:"note,omitempty"`
+}
+
+// handleDatabaseNPlusOne runs an on-demand, bounded Tempo scan for N+1 query
+// patterns in this service's traces.
+// GET /services/{namespace}/{service}/database/nplusone?from=&to=&tracesUid=
+func (a *App) handleDatabaseNPlusOne(w http.ResponseWriter, req *http.Request) {
+	if !requireGET(w, req) {
+		return
+	}
+	ctx := a.requestContext(req)
+	namespace, service := parseServiceRef(req)
+	if !requireServiceParam(w, service) {
+		return
+	}
+	from, to := parseTimeRange(req)
+	// Cost bound: clamp the window to the most-recent cap.
+	from = clampWindow(from, to, nplusoneWindowCap)
+
+	tracesUID := sanitizeDatasourceUID(req.URL.Query().Get("tracesUid"))
+	// Confused-deputy hardening: only the configured traces datasource(s) may be
+	// proxied with the SA token (mirrors handleDatabaseQueries).
+	if tracesUID == "" || !a.settings.TracesDataSource.Allows(tracesUID) {
+		writeJSON(w, NPlusOneResponse{Mode: "unavailable", Findings: []NPlusOneFinding{}, Threshold: nplusoneRepeatThreshold, Note: "traces datasource not configured"})
+		return
+	}
+
+	orgID := req.Header.Get("X-Grafana-Org-Id")
+	ck := cacheKey("dbnplusone", orgID, roundedUnix(from), roundedUnix(to), namespace, service, tracesUID)
+	headers := req.Header
+	a.writeCached(w, ck, "scanning for N+1 query patterns failed", func() (any, error) {
+		return a.scanNPlusOne(ctx, headers, tracesUID, namespace, service, from, to), nil
+	})
+}
+
+// scanNPlusOne runs the bounded candidate-trace search, groups each trace's DB
+// spans by normalized statement, and returns the repeated-query offenders.
+// Degrades to an "unavailable" response (never hangs) when Tempo errors/times out.
+func (a *App) scanNPlusOne(ctx context.Context, headers http.Header, tracesUID, namespace, service string, from, to time.Time) NPlusOneResponse {
+	logger := log.DefaultLogger.With("handler", "database-nplusone")
+	windowSec := int(to.Sub(from).Seconds())
+
+	traces, truncated, err := a.searchNPlusOneTraces(ctx, headers, tracesUID, namespace, service, from, to)
+	if err != nil {
+		logger.Warn("Tempo N+1 candidate search failed", "service", sanitizeLogValue(service), "error", err)
+		return NPlusOneResponse{
+			Mode: "unavailable", Findings: []NPlusOneFinding{}, WindowSeconds: windowSec,
+			Threshold: nplusoneRepeatThreshold,
+			Note:      "trace search unavailable (Tempo may be busy) — try a narrower range",
+		}
+	}
+
+	findings := detectNPlusOne(traces, nplusoneRepeatThreshold, nplusoneMaxFindings)
+	return NPlusOneResponse{
+		Mode:          "traceql",
+		Findings:      findings,
+		ScannedTraces: len(traces),
+		Truncated:     truncated,
+		WindowSeconds: windowSec,
+		Threshold:     nplusoneRepeatThreshold,
+	}
+}
+
+// nplusTrace is one candidate trace: its endpoint (root span) and DB spans.
+type nplusTrace struct {
+	traceID  string
+	endpoint string
+	spans    []dbSpan
+}
+
+// detectNPlusOne groups each trace's DB spans by (db.system, normalized
+// statement) and emits a finding for every group repeated at least `threshold`
+// times in that one trace. Findings are ordered by repeat count desc (the worst
+// offenders first) and capped at `limit`.
+//nolint:unparam // threshold is a tunable N+1 sensitivity knob (§9); kept a param so the grouping logic is exercised at other thresholds in tests.
+func detectNPlusOne(traces []nplusTrace, threshold, limit int) []NPlusOneFinding {
+	findings := make([]NPlusOneFinding, 0)
+	for _, tr := range traces {
+		type group struct {
+			system string
+			table  string
+			norm   string
+			count  int
+		}
+		groups := make(map[string]*group)
+		for _, s := range tr.spans {
+			norm := normalizeStatement(s.system, s.statement)
+			if norm == "" {
+				continue
+			}
+			key := s.system + "\x00" + norm
+			g := groups[key]
+			if g == nil {
+				g = &group{system: s.system, norm: norm}
+				groups[key] = g
+			}
+			if g.table == "" && s.table != "" {
+				g.table = s.table
+			}
+			g.count++
+		}
+		totalDBSpans := len(tr.spans)
+		for _, g := range groups {
+			if g.count < threshold {
+				continue
+			}
+			findings = append(findings, NPlusOneFinding{
+				Statement:    g.norm,
+				DBSystem:     g.system,
+				Table:        g.table,
+				RepeatCount:  g.count,
+				Endpoint:     tr.endpoint,
+				TotalDBSpans: totalDBSpans,
+				TraceID:      tr.traceID,
+				Remediation:  remediationHint(g.system),
+			})
+		}
+	}
+
+	// Worst offenders first; stable tiebreak so output is deterministic.
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].RepeatCount != findings[j].RepeatCount {
+			return findings[i].RepeatCount > findings[j].RepeatCount
+		}
+		if findings[i].Endpoint != findings[j].Endpoint {
+			return findings[i].Endpoint < findings[j].Endpoint
+		}
+		return findings[i].Statement < findings[j].Statement
+	})
+	if len(findings) > limit {
+		findings = findings[:limit]
+	}
+	return findings
+}
+
+// remediationHint returns the per-system fix for a repeated-query pattern (§5).
+// Unknown systems fall through to the SQL advice (the common case).
+func remediationHint(system string) string {
+	switch classifyDBFamily(system) {
+	case familyKeyValue:
+		return "Batch the repeated lookups into one round-trip — use MGET (or a pipeline / MULTI) instead of a GET per key."
+	case familyDocument:
+		if isOpenSearchLike(system) {
+			return "Collapse the repeated searches into a single bulk or multi-search (_msearch) request."
+		}
+		return "Fetch the documents in one query — use $in on the id field, or an aggregation, instead of a find() per document."
+	default:
+		// postgresql / oracle / db2 / h2 / other_sql.
+		if isOracle(system) {
+			return "Replace the per-row queries with a JOIN or a batch fetch (IN (…)); if it must stay, check the plan/index for the repeated statement."
+		}
+		return "Replace the per-row queries with a JOIN, a batch fetch, or a single IN (…) clause instead of one query per row."
+	}
+}
+
+func isOpenSearchLike(system string) bool {
+	switch system {
+	case "opensearch", "elasticsearch":
+		return true
+	}
+	return false
+}
+
+func isOracle(system string) bool {
+	return system == "oracle"
+}
+
+// searchNPlusOneTraces runs one bounded TraceQL scan for candidate traces —
+// those with more DB client spans than the repeat floor — pulling each span's
+// db.statement/system/table via select(), grouped per trace. Returns the
+// candidate traces and whether the trace limit was hit.
+//
+// TraceQL: { <svc> = "…" [&& <ns> = "…"] && span.db.system != "" }
+//          | select(span.db.statement, span.db.system, span.db.sql.table)
+//          | count() > <repeat-1>
+func (a *App) searchNPlusOneTraces(ctx context.Context, headers http.Header, tracesUID, namespace, service string, from, to time.Time) ([]nplusTrace, bool, error) {
+	base := a.proxyURL(tracesUID)
+	if base == "" {
+		return nil, false, fmt.Errorf("traces datasource not configured")
+	}
+
+	svc := a.otelCfg.TraceQL.ServiceName
+	selector := fmt.Sprintf(`{ %s = %q && span.db.system != "" }`, svc, service)
+	if namespace != "" {
+		selector = fmt.Sprintf(`{ %s = %q && %s = %q && span.db.system != "" }`,
+			svc, service, a.otelCfg.TraceQL.ServiceNamespace, namespace)
+	}
+	// count() > (repeat-1) is the candidate floor: a trace cannot repeat a single
+	// statement `repeat` times unless it holds at least that many DB spans. The
+	// exact per-statement duplicate count is confirmed in detectNPlusOne.
+	query := selector +
+		` | select(span.db.statement, span.db.system, span.db.sql.table)` +
+		fmt.Sprintf(` | count() > %d`, nplusoneRepeatThreshold-1)
+
+	q := url.Values{
+		"q":     {query},
+		"limit": {strconv.Itoa(nplusoneTraceLimit)},
+		"spss":  {strconv.Itoa(nplusoneSpansPerSet)},
+		"start": {strconv.FormatInt(from.Unix(), 10)},
+		"end":   {strconv.FormatInt(to.Unix(), 10)},
+	}
+	reqURL := base + "/api/search?" + q.Encode()
+
+	ctx, cancel := context.WithTimeout(ctx, nplusoneTimeout)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	applyProxyAuth(httpReq, headers, a.resolveServiceToken(ctx))
+
+	client := &http.Client{Timeout: nplusoneTimeout}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close() //nolint:errcheck
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, false, fmt.Errorf("tempo search returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	if err != nil {
+		return nil, false, err
+	}
+	traces := parseNPlusOneResponse(body)
+	return traces, len(traces) >= nplusoneTraceLimit, nil
+}
+
+// parseNPlusOneResponse groups the search response by trace (unlike the
+// top-queries parser, which flattens), keeping each trace's endpoint (root span)
+// so detectNPlusOne can attribute the N+1 to a request. Spans are deduped by
+// spanID (Tempo echoes them under both spanSet and spanSets).
+func parseNPlusOneResponse(body []byte) []nplusTrace {
+	var parsed tempoSearchResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil
+	}
+	var out []nplusTrace
+	for _, t := range parsed.Traces {
+		sets := t.SpanSets
+		if len(sets) == 0 && t.SpanSet != nil {
+			sets = []tempoSpanSet{*t.SpanSet}
+		}
+		tr := nplusTrace{traceID: t.TraceID, endpoint: rootEndpointName(t.RootServiceName, t.RootTraceName)}
+		seen := make(map[string]struct{})
+		for _, ss := range sets {
+			for _, sp := range ss.Spans {
+				if sp.SpanID != "" {
+					if _, dup := seen[sp.SpanID]; dup {
+						continue
+					}
+					seen[sp.SpanID] = struct{}{}
+				}
+				span := dbSpan{traceID: t.TraceID}
+				for _, attr := range sp.Attributes {
+					switch attr.Key {
+					case "db.statement":
+						span.statement = attr.Value.StringValue
+					case "db.system":
+						span.system = attr.Value.StringValue
+					case "db.sql.table":
+						span.table = attr.Value.StringValue
+					}
+				}
+				if span.statement == "" {
+					continue
+				}
+				if ns, err := strconv.ParseFloat(sp.DurationNanos, 64); err == nil {
+					span.durationMs = ns / 1e6
+				}
+				tr.spans = append(tr.spans, span)
+			}
+		}
+		if len(tr.spans) == 0 {
+			continue
+		}
+		out = append(out, tr)
+	}
+	return out
+}
+
+// rootEndpointName labels the request a trace belongs to. Tempo's root span name
+// (e.g. "GET /oppgaveliste.jsf") is the endpoint; the root service name is only
+// prefixed when it differs from this service (a downstream-owned root). Falls
+// back gracefully when Tempo omitted the root metadata.
+func rootEndpointName(rootService, rootTrace string) string {
+	if rootTrace == "" {
+		if rootService != "" {
+			return rootService
+		}
+		return "unknown request"
+	}
+	return rootTrace
+}

--- a/pkg/plugin/dbnplusone_test.go
+++ b/pkg/plugin/dbnplusone_test.go
@@ -1,0 +1,226 @@
+package plugin
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// detectNPlusOne must group each trace's DB spans by normalized statement and
+// emit a finding only when one fingerprint repeats at least the threshold times
+// within a single trace — attributing it to that trace's endpoint.
+func TestDetectNPlusOne(t *testing.T) {
+	var offenders []dbSpan
+	// 12 SELECTs with differing IN-arity → one normalized group, 12 repeats.
+	for i := 0; i < 12; i++ {
+		offenders = append(offenders, dbSpan{system: "postgresql", statement: "select * from person where id in (?, ?)", table: "person"})
+	}
+	// A couple of unrelated one-off queries in the same trace → below threshold.
+	offenders = append(offenders,
+		dbSpan{system: "postgresql", statement: "select count(*) from account"},
+		dbSpan{system: "postgresql", statement: "update session set seen = now() where id = 7"},
+	)
+
+	traces := []nplusTrace{
+		{traceID: "t1", endpoint: "GET /oppgaveliste.jsf", spans: offenders},
+		// A clean trace: 3 different queries, none repeated → no finding.
+		{traceID: "t2", endpoint: "GET /healthz", spans: []dbSpan{
+			{system: "postgresql", statement: "select 1"},
+			{system: "postgresql", statement: "select 2"},
+			{system: "postgresql", statement: "select 3"},
+		}},
+	}
+
+	got := detectNPlusOne(traces, 10, 50)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(got), got)
+	}
+	f := got[0]
+	if f.RepeatCount != 12 {
+		t.Errorf("repeat count = %d, want 12", f.RepeatCount)
+	}
+	if f.Statement != "select * from person where id in (?)" {
+		t.Errorf("statement not normalized/collapsed: %q", f.Statement)
+	}
+	if f.Endpoint != "GET /oppgaveliste.jsf" {
+		t.Errorf("endpoint wrong: %q", f.Endpoint)
+	}
+	if f.TraceID != "t1" {
+		t.Errorf("traceID wrong: %q", f.TraceID)
+	}
+	if f.Table != "person" {
+		t.Errorf("table not carried: %q", f.Table)
+	}
+	// 12 offenders + 2 one-offs observed in the trace.
+	if f.TotalDBSpans != 14 {
+		t.Errorf("totalDbSpans = %d, want 14", f.TotalDBSpans)
+	}
+	if !strings.Contains(strings.ToLower(f.Remediation), "join") {
+		t.Errorf("SQL remediation should suggest a JOIN: %q", f.Remediation)
+	}
+}
+
+// A single trace can hold several distinct N+1 offenders; each is its own
+// finding, and findings are ordered worst-first (by repeat count).
+func TestDetectNPlusOne_MultipleOffendersOrdered(t *testing.T) {
+	var spans []dbSpan
+	for i := 0; i < 10; i++ {
+		spans = append(spans, dbSpan{system: "postgresql", statement: "select a from t1 where id = 1"})
+	}
+	for i := 0; i < 30; i++ {
+		spans = append(spans, dbSpan{system: "redis", statement: "GET user:" + string(rune('a'+i))})
+	}
+	traces := []nplusTrace{{traceID: "t1", endpoint: "POST /submit", spans: spans}}
+
+	got := detectNPlusOne(traces, 10, 50)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(got))
+	}
+	// Redis (30) must lead postgres (10).
+	if got[0].DBSystem != "redis" || got[0].RepeatCount != 30 {
+		t.Errorf("worst offender should be redis×30, got %+v", got[0])
+	}
+	if got[1].DBSystem != "postgresql" || got[1].RepeatCount != 10 {
+		t.Errorf("second finding wrong: %+v", got[1])
+	}
+	// Redis keys are stripped to the verb fingerprint (PII-safe).
+	if got[0].Statement != "GET ?" {
+		t.Errorf("redis statement should be normalized to 'GET ?', got %q", got[0].Statement)
+	}
+	if !strings.Contains(got[0].Remediation, "MGET") {
+		t.Errorf("redis remediation should suggest MGET/pipeline: %q", got[0].Remediation)
+	}
+}
+
+// Just-below-threshold repetition must not be flagged.
+func TestDetectNPlusOne_BelowThreshold(t *testing.T) {
+	var spans []dbSpan
+	for i := 0; i < 9; i++ {
+		spans = append(spans, dbSpan{system: "postgresql", statement: "select * from t where id = 1"})
+	}
+	got := detectNPlusOne([]nplusTrace{{traceID: "t1", endpoint: "GET /x", spans: spans}}, 10, 50)
+	if len(got) != 0 {
+		t.Fatalf("9 repeats is below the threshold of 10, want 0 findings, got %d", len(got))
+	}
+}
+
+func TestDetectNPlusOne_Limit(t *testing.T) {
+	var traces []nplusTrace
+	for tI := 0; tI < 5; tI++ {
+		var spans []dbSpan
+		for i := 0; i < 10; i++ {
+			spans = append(spans, dbSpan{system: "postgresql", statement: "select x from t where id = 1"})
+		}
+		traces = append(traces, nplusTrace{traceID: "t" + strconv.Itoa(tI), endpoint: "GET /x", spans: spans})
+	}
+	got := detectNPlusOne(traces, 10, 3)
+	if len(got) != 3 {
+		t.Fatalf("limit not applied: got %d findings", len(got))
+	}
+}
+
+func TestRemediationHint(t *testing.T) {
+	cases := map[string]string{
+		"postgresql":    "JOIN",
+		"db2":           "JOIN",
+		"other_sql":     "JOIN",
+		"oracle":        "plan/index",
+		"redis":         "MGET",
+		"valkey":        "MGET",
+		"mongodb":       "$in",
+		"opensearch":    "multi-search",
+		"elasticsearch": "multi-search",
+	}
+	for system, want := range cases {
+		if hint := remediationHint(system); !strings.Contains(hint, want) {
+			t.Errorf("remediationHint(%q) = %q, want it to mention %q", system, hint, want)
+		}
+	}
+}
+
+// parseNPlusOneResponse must group by trace, carry the root span as the
+// endpoint, dedupe echoed spans, and pull the select()'ed attributes.
+func TestParseNPlusOneResponse(t *testing.T) {
+	body := []byte(`{
+      "traces": [
+        {
+          "traceID": "abc",
+          "rootServiceName": "gosys",
+          "rootTraceName": "GET /oppgaveliste.jsf",
+          "spanSet":  {"spans": [{"spanID": "s1", "durationNanos": "1000000", "attributes": [
+            {"key": "db.system", "value": {"stringValue": "postgresql"}},
+            {"key": "db.statement", "value": {"stringValue": "select * from t where id = 1"}}
+          ]}]},
+          "spanSets": [{"spans": [
+            {"spanID": "s1", "durationNanos": "1000000", "attributes": [
+              {"key": "db.system", "value": {"stringValue": "postgresql"}},
+              {"key": "db.statement", "value": {"stringValue": "select * from t where id = 1"}}
+            ]},
+            {"spanID": "s2", "durationNanos": "2000000", "attributes": [
+              {"key": "db.system", "value": {"stringValue": "postgresql"}},
+              {"key": "db.statement", "value": {"stringValue": "select * from t where id = 2"}}
+            ]}
+          ]}]
+        }
+      ]
+    }`)
+
+	traces := parseNPlusOneResponse(body)
+	if len(traces) != 1 {
+		t.Fatalf("expected 1 trace, got %d", len(traces))
+	}
+	tr := traces[0]
+	if tr.endpoint != "GET /oppgaveliste.jsf" {
+		t.Errorf("endpoint wrong: %q", tr.endpoint)
+	}
+	// s1 echoed under both spanSet and spanSets → deduped to 1; plus s2 = 2.
+	if len(tr.spans) != 2 {
+		t.Fatalf("expected 2 deduped spans, got %d: %+v", len(tr.spans), tr.spans)
+	}
+}
+
+func TestParseNPlusOneResponse_Garbage(t *testing.T) {
+	if got := parseNPlusOneResponse([]byte("not json")); got != nil {
+		t.Errorf("garbage should parse to nothing, got %v", got)
+	}
+}
+
+func TestRootEndpointName(t *testing.T) {
+	if got := rootEndpointName("gosys", "GET /x"); got != "GET /x" {
+		t.Errorf("root trace name should win: %q", got)
+	}
+	if got := rootEndpointName("gosys", ""); got != "gosys" {
+		t.Errorf("fallback to root service: %q", got)
+	}
+	if got := rootEndpointName("", ""); got != "unknown request" {
+		t.Errorf("fallback to placeholder: %q", got)
+	}
+}
+
+// The handler must reject an unconfigured/disallowed traces datasource with a
+// graceful "unavailable" payload rather than proxying it.
+func TestHandleDatabaseNPlusOne_UnconfiguredDatasource(t *testing.T) {
+	a := &App{}
+	req := httptest.NewRequest("GET", "/services/myns/mysvc/database/nplusone?tracesUid=evil", nil)
+	req.SetPathValue("namespace", "myns")
+	req.SetPathValue("service", "mysvc")
+	rec := httptest.NewRecorder()
+
+	a.handleDatabaseNPlusOne(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp NPlusOneResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Mode != "unavailable" {
+		t.Errorf("mode = %q, want unavailable", resp.Mode)
+	}
+	if resp.Threshold != nplusoneRepeatThreshold {
+		t.Errorf("threshold = %d, want %d", resp.Threshold, nplusoneRepeatThreshold)
+	}
+}

--- a/pkg/plugin/dbqueries.go
+++ b/pkg/plugin/dbqueries.go
@@ -103,6 +103,8 @@ func (a *App) handleDatabaseQueries(w http.ResponseWriter, req *http.Request) {
 
 // clampWindow returns a from no earlier than to-cap, so a wide selected range
 // only ever hits Tempo for the most-recent cap-sized slice.
+//
+//nolint:unparam // cap is a per-feature tunable window bound (top-queries and the N+1 scan both currently pass 1h).
 func clampWindow(from, to time.Time, cap time.Duration) time.Time {
 	if earliest := to.Add(-cap); from.Before(earliest) {
 		return earliest
@@ -289,11 +291,16 @@ func (a *App) searchDBSpans(ctx context.Context, headers http.Header, tracesUID,
 }
 
 // tempoSearchResponse is the subset of Tempo's /api/search JSON we consume.
+// RootServiceName/RootTraceName identify the request the trace belongs to; the
+// N+1 scan (dbnplusone.go) uses them to name the offending endpoint. Top-queries
+// ignores them.
 type tempoSearchResponse struct {
 	Traces []struct {
-		TraceID  string         `json:"traceID"`
-		SpanSet  *tempoSpanSet  `json:"spanSet"`
-		SpanSets []tempoSpanSet `json:"spanSets"`
+		TraceID         string         `json:"traceID"`
+		RootServiceName string         `json:"rootServiceName"`
+		RootTraceName   string         `json:"rootTraceName"`
+		SpanSet         *tempoSpanSet  `json:"spanSet"`
+		SpanSets        []tempoSpanSet `json:"spanSets"`
 	} `json:"traces"`
 }
 

--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -154,3 +154,61 @@ export async function getTopQueries(
     }
   );
 }
+
+// ---- N+1 query-pattern scan (issue #119 Phase 3) ----
+
+export type NPlusOneMode = 'traceql' | 'unavailable';
+
+export interface NPlusOneFinding {
+  /** Normalized statement fingerprint — never a raw literal (PII-safe). */
+  statement: string;
+  dbSystem: string;
+  /** db.sql.table when the driver populates it; often empty. */
+  table?: string;
+  /** How many times this normalized statement ran in the one request. */
+  repeatCount: number;
+  /** Root span / route the request entered through. */
+  endpoint: string;
+  /** DB spans observed in the trace (a bounded sample). */
+  totalDbSpans: number;
+  /** The offending trace, for the drill-down link. */
+  traceId: string;
+  /** Per-system remediation hint (JOIN/batch, MGET/pipeline, $in, …). */
+  remediation: string;
+}
+
+export interface NPlusOneResponse {
+  mode: NPlusOneMode;
+  findings: NPlusOneFinding[];
+  /** Candidate traces the scan inspected. */
+  scannedTraces: number;
+  /** True when the candidate-trace scan limit was hit. */
+  truncated: boolean;
+  /** Effective (possibly clamped) window scanned, in seconds. */
+  windowSeconds: number;
+  /** Per-trace repeat count that qualifies a finding. */
+  threshold: number;
+  note?: string;
+}
+
+/**
+ * On-demand N+1 query-pattern scan for a service, from a bounded, cached Tempo
+ * trace search on the backend. Triggered explicitly (a "Scan for N+1" action),
+ * never continuously — the backend owns the Tempo cost bounds, normalization,
+ * and the cache.
+ */
+export async function scanNPlusOne(
+  namespace: string,
+  service: string,
+  from: number,
+  to: number,
+  tracesUid: string
+): Promise<NPlusOneResponse> {
+  return fetchResource<NPlusOneResponse>(
+    `/services/${nsParam(namespace)}/${encodeURIComponent(service)}/database/nplusone`,
+    {
+      ...timeParams(from, to),
+      tracesUid,
+    }
+  );
+}

--- a/src/pages/tabs/DatabaseTab.tsx
+++ b/src/pages/tabs/DatabaseTab.tsx
@@ -15,6 +15,7 @@ import { useSceneTimeSync } from '../../utils/useSceneTimeSync';
 import { QueryOperationsTable } from './database/QueryOperationsTable';
 import { ConnectionPoolSection } from './database/ConnectionPoolSection';
 import { TopQueriesSection } from './database/TopQueriesSection';
+import { NPlusOneSection } from './database/NPlusOneSection';
 
 interface DatabaseTabProps {
   service: string;
@@ -216,6 +217,16 @@ export function DatabaseTab({
 
         {hasDbSpans && ds.tracesUid && (caps?.tempo?.available ?? true) && (
           <TopQueriesSection
+            namespace={namespace}
+            service={service}
+            fromMs={fromMs}
+            toMs={toMs}
+            tracesUid={ds.tracesUid}
+          />
+        )}
+
+        {hasDbSpans && ds.tracesUid && (caps?.tempo?.available ?? true) && (
+          <NPlusOneSection
             namespace={namespace}
             service={service}
             fromMs={fromMs}

--- a/src/pages/tabs/database/NPlusOneSection.test.tsx
+++ b/src/pages/tabs/database/NPlusOneSection.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { NPlusOneSection } from './NPlusOneSection';
+import * as analytics from '../../../api/analytics';
+import { NPlusOneResponse } from '../../../api/analytics';
+
+jest.mock('../../../api/analytics');
+const mockScanNPlusOne = analytics.scanNPlusOne as jest.MockedFunction<typeof analytics.scanNPlusOne>;
+
+const baseResponse: NPlusOneResponse = {
+  mode: 'traceql',
+  scannedTraces: 12,
+  truncated: false,
+  windowSeconds: 3600,
+  threshold: 10,
+  findings: [
+    {
+      statement: 'select * from person where id in (?)',
+      dbSystem: 'postgresql',
+      table: 'person',
+      repeatCount: 40,
+      endpoint: 'GET /oppgaveliste.jsf',
+      totalDbSpans: 90,
+      traceId: 'abc123',
+      remediation: 'Replace the per-row queries with a JOIN, a batch fetch, or a single IN (…) clause.',
+    },
+    {
+      statement: 'GET ?',
+      dbSystem: 'redis',
+      repeatCount: 15,
+      endpoint: 'POST /submit',
+      totalDbSpans: 20,
+      traceId: 'def456',
+      remediation: 'Batch the repeated lookups into one round-trip — use MGET (or a pipeline / MULTI).',
+    },
+  ],
+};
+
+const renderSection = () =>
+  render(
+    <MemoryRouter>
+      <NPlusOneSection namespace="myns" service="mysvc" fromMs={1000} toMs={2000} tracesUid="tempo-uid" />
+    </MemoryRouter>
+  );
+
+describe('NPlusOneSection', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('does not scan until the user clicks the button (on-demand)', () => {
+    mockScanNPlusOne.mockResolvedValue(baseResponse);
+    renderSection();
+    expect(mockScanNPlusOne).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /Scan for N\+1/ })).toBeInTheDocument();
+  });
+
+  it('renders findings with endpoint, repeat count, trace link and remediation on scan', async () => {
+    mockScanNPlusOne.mockResolvedValue(baseResponse);
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: /Scan for N\+1/ }));
+
+    await waitFor(() => expect(screen.getByText('select * from person where id in (?)')).toBeInTheDocument());
+    expect(mockScanNPlusOne).toHaveBeenCalledTimes(1);
+
+    // Endpoint + repeat-count framing.
+    expect(screen.getByText('GET /oppgaveliste.jsf')).toBeInTheDocument();
+    expect(screen.getByText('POST /submit')).toBeInTheDocument();
+    expect(screen.getByText('40× in one request')).toBeInTheDocument();
+
+    // Per-system remediation hints render.
+    expect(screen.getByText(/use a JOIN|Replace the per-row queries/i)).toBeInTheDocument();
+    expect(screen.getByText(/MGET/)).toBeInTheDocument();
+
+    // Trace links point at the traceId via TraceQL Explore.
+    const links = screen.getAllByRole('link', { name: 'View offending trace' });
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', expect.stringContaining('abc123'));
+  });
+
+  it('shows a clean "no N+1" state when the scan finds nothing', async () => {
+    mockScanNPlusOne.mockResolvedValue({
+      mode: 'traceql',
+      findings: [],
+      scannedTraces: 5,
+      truncated: false,
+      windowSeconds: 3600,
+      threshold: 10,
+    });
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: /Scan for N\+1/ }));
+    await waitFor(() => expect(screen.getByText(/No N\+1 patterns found/i)).toBeInTheDocument());
+  });
+
+  it('shows a graceful notice when trace search is unavailable', async () => {
+    mockScanNPlusOne.mockResolvedValue({
+      mode: 'unavailable',
+      findings: [],
+      scannedTraces: 0,
+      truncated: false,
+      windowSeconds: 3600,
+      threshold: 10,
+      note: 'trace search unavailable (Tempo may be busy) — try a narrower range',
+    });
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: /Scan for N\+1/ }));
+    await waitFor(() => expect(screen.getByText(/trace search unavailable/i)).toBeInTheDocument());
+    expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+  });
+
+  it('reports a bounded sample when the scan was truncated', async () => {
+    mockScanNPlusOne.mockResolvedValue({ ...baseResponse, truncated: true });
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: /Scan for N\+1/ }));
+    await waitFor(() => expect(screen.getByText(/scan limit was reached/i)).toBeInTheDocument());
+  });
+});

--- a/src/pages/tabs/database/NPlusOneSection.tsx
+++ b/src/pages/tabs/database/NPlusOneSection.tsx
@@ -1,0 +1,288 @@
+import React, { useState } from 'react';
+import { useStyles2, Icon, Button, Tooltip, Badge } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
+import { scanNPlusOne, NPlusOneFinding } from '../../../api/analytics';
+import { useFetch } from '../../../utils/useFetch';
+import { DepTypeIcon } from '../../../components/DepTypeIcon';
+import { buildExploreUrl } from '../../../utils/explore';
+
+interface NPlusOneSectionProps {
+  namespace: string;
+  service: string;
+  fromMs: number;
+  toMs: number;
+  tracesUid: string;
+}
+
+/**
+ * "N+1 candidates" — the Database tab's confirm layer for N+1 query patterns
+ * (issue #119 §4.3). Answers "where am I hammering the database?" by scanning a
+ * bounded, cached sample of this service's traces for the same normalized
+ * db.statement repeated many times within a single request.
+ *
+ * On-demand by design (§6, cost): nothing runs until the developer clicks "Scan
+ * for N+1" — Tempo is cost-sensitive, so this is an explicit action, not a
+ * background sweep. The backend owns the cost bounds, the normalization (every
+ * statement here is a fingerprint, never a raw literal, §6), and the cache. Each
+ * finding carries a per-system remediation hint (§5).
+ */
+export function NPlusOneSection({ namespace, service, fromMs, toMs, tracesUid }: NPlusOneSectionProps) {
+  const styles = useStyles2(getStyles);
+  const [scanned, setScanned] = useState(false);
+
+  const { data, loading, error, refetch } = useFetch(
+    () => scanNPlusOne(namespace, service, fromMs, toMs, tracesUid),
+    [namespace, service, fromMs, toMs, tracesUid],
+    { skip: !scanned }
+  );
+
+  const findings = data?.findings ?? [];
+  const unavailable = data?.mode === 'unavailable';
+  const hasResult = scanned && !loading && !error && !unavailable && !!data;
+  const isEmpty = hasResult && findings.length === 0;
+
+  return (
+    <div className={styles.section}>
+      <div className={styles.headerRow}>
+        <div>
+          <h4 className={styles.sectionTitle}>N+1 candidates</h4>
+          <p className={styles.sectionSubtitle}>
+            Scans a bounded, cached sample of this service&apos;s traces for the same normalized query repeated many
+            times in a single request — the classic N+1 that a JOIN, batch-fetch, or pipeline collapses. On-demand,
+            because trace scans are cost-sensitive. Statements are stripped to a fingerprint before display.
+          </p>
+        </div>
+        <Button
+          variant={scanned ? 'secondary' : 'primary'}
+          size="sm"
+          icon={loading ? 'fa fa-spinner' : 'search'}
+          disabled={loading}
+          onClick={() => (scanned ? refetch() : setScanned(true))}
+        >
+          {loading ? 'Scanning…' : scanned ? 'Re-scan' : 'Scan for N+1'}
+        </Button>
+      </div>
+
+      {error && (
+        <div className={styles.notice}>
+          <Icon name="exclamation-triangle" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {unavailable && (
+        <div className={styles.notice}>
+          <Icon name="exclamation-triangle" />
+          <span>
+            {data?.note || 'Trace search is currently unavailable. Try again shortly or narrow the time range.'}
+          </span>
+        </div>
+      )}
+
+      {isEmpty && (
+        <div className={styles.notice}>
+          <Icon name="check-circle" />
+          <span>
+            No N+1 patterns found — no single request repeated the same query {data?.threshold ?? 10}× or more in the
+            scanned window ({data ? formatWindow(data.windowSeconds) : ''}). Widen the range if you expected some.
+          </span>
+        </div>
+      )}
+
+      {hasResult && findings.length > 0 && (
+        <>
+          <ul className={styles.findingList}>
+            {findings.map((f, i) => (
+              <FindingCard key={`${f.traceId}:${f.dbSystem}:${f.statement}:${i}`} finding={f} tracesUid={tracesUid} />
+            ))}
+          </ul>
+          <p className={styles.footnote}>
+            Scanned {data.scannedTraces.toLocaleString()} candidate trace{data.scannedTraces === 1 ? '' : 's'} over the
+            last {formatWindow(data.windowSeconds)}
+            {data.truncated && ' (bounded sample — the scan limit was reached)'}.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+function FindingCard({ finding, tracesUid }: { finding: NPlusOneFinding; tracesUid: string }) {
+  const styles = useStyles2(getStyles);
+
+  const traceHref = finding.traceId
+    ? buildExploreUrl({
+        datasourceUid: tracesUid,
+        queries: [{ refId: 'A', queryType: 'traceql', query: finding.traceId }],
+      })
+    : undefined;
+
+  return (
+    <li className={styles.findingCard}>
+      <div className={styles.findingHead}>
+        <span className={styles.systemCell}>
+          <DepTypeIcon type={finding.dbSystem} size={16} />
+          <span>{finding.dbSystem}</span>
+        </span>
+        <Badge text={`${finding.repeatCount}× in one request`} color="red" />
+        {finding.table && <span className={styles.tableTag}>{finding.table}</span>}
+        {traceHref && (
+          <Tooltip content="View the offending trace">
+            <a
+              href={traceHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.traceLink}
+              aria-label="View offending trace"
+            >
+              <Icon name="compass" size="sm" /> trace
+            </a>
+          </Tooltip>
+        )}
+      </div>
+      <p className={styles.findingSummary}>
+        <span className={styles.endpoint}>{finding.endpoint}</span> ran{' '}
+        <code className={styles.statement}>{finding.statement}</code>{' '}
+        <strong>
+          {finding.repeatCount}× ({finding.totalDbSpans} DB span{finding.totalDbSpans === 1 ? '' : 's'} in the request)
+        </strong>
+      </p>
+      <p className={styles.remediation}>
+        <Icon name="wrench" size="sm" /> {finding.remediation}
+      </p>
+    </li>
+  );
+}
+
+function formatWindow(seconds: number): string {
+  if (seconds >= 3600) {
+    const h = seconds / 3600;
+    return `${h % 1 === 0 ? h : h.toFixed(1)}h`;
+  }
+  if (seconds >= 60) {
+    return `${Math.round(seconds / 60)}m`;
+  }
+  return `${seconds}s`;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  section: css`
+    display: flex;
+    flex-direction: column;
+  `,
+  headerRow: css`
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: ${theme.spacing(2)};
+  `,
+  sectionTitle: css`
+    font-size: ${theme.typography.h5.fontSize};
+    font-weight: ${theme.typography.fontWeightMedium};
+    margin: 0 0 ${theme.spacing(0.5)} 0;
+    color: ${theme.colors.text.primary};
+  `,
+  sectionSubtitle: css`
+    font-size: ${theme.typography.bodySmall.fontSize};
+    color: ${theme.colors.text.secondary};
+    margin: 0 0 ${theme.spacing(1)} 0;
+  `,
+  findingList: css`
+    list-style: none;
+    margin: ${theme.spacing(1)} 0 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacing(1)};
+  `,
+  findingCard: css`
+    border: 1px solid ${theme.colors.border.weak};
+    border-left: 3px solid ${theme.colors.error.border};
+    border-radius: ${theme.shape.radius.default};
+    background: ${theme.colors.background.secondary};
+    padding: ${theme.spacing(1.5)};
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacing(0.75)};
+  `,
+  findingHead: css`
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: ${theme.spacing(1)};
+  `,
+  systemCell: css`
+    display: inline-flex;
+    align-items: center;
+    gap: ${theme.spacing(0.75)};
+    color: ${theme.colors.text.secondary};
+    font-size: ${theme.typography.bodySmall.fontSize};
+    text-transform: capitalize;
+  `,
+  findingSummary: css`
+    margin: 0;
+    font-size: ${theme.typography.bodySmall.fontSize};
+    color: ${theme.colors.text.primary};
+    line-height: 1.5;
+  `,
+  endpoint: css`
+    font-family: ${theme.typography.fontFamilyMonospace};
+    color: ${theme.colors.text.primary};
+  `,
+  statement: css`
+    font-family: ${theme.typography.fontFamilyMonospace};
+    font-size: ${theme.typography.bodySmall.fontSize};
+    background: ${theme.colors.background.primary};
+    border: 1px solid ${theme.colors.border.weak};
+    border-radius: ${theme.shape.radius.default};
+    padding: 0 ${theme.spacing(0.5)};
+    word-break: break-word;
+  `,
+  tableTag: css`
+    display: inline-block;
+    padding: 0 ${theme.spacing(0.75)};
+    border-radius: ${theme.shape.radius.default};
+    background: ${theme.colors.background.primary};
+    border: 1px solid ${theme.colors.border.weak};
+    color: ${theme.colors.text.secondary};
+    font-size: ${theme.typography.bodySmall.fontSize};
+    font-family: ${theme.typography.fontFamilyMonospace};
+  `,
+  remediation: css`
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(0.75)};
+    font-size: ${theme.typography.bodySmall.fontSize};
+    color: ${theme.colors.text.secondary};
+  `,
+  traceLink: css`
+    display: inline-flex;
+    align-items: center;
+    gap: ${theme.spacing(0.25)};
+    margin-left: auto;
+    color: ${theme.colors.text.secondary};
+    font-size: ${theme.typography.bodySmall.fontSize};
+    &:hover {
+      color: ${theme.colors.text.link};
+    }
+  `,
+  notice: css`
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(1)};
+    padding: ${theme.spacing(1.5)};
+    margin-top: ${theme.spacing(1)};
+    border: 1px solid ${theme.colors.border.weak};
+    border-radius: ${theme.shape.radius.default};
+    background: ${theme.colors.background.secondary};
+    color: ${theme.colors.text.secondary};
+    font-size: ${theme.typography.bodySmall.fontSize};
+  `,
+  footnote: css`
+    margin: ${theme.spacing(1)} 0 0 0;
+    font-size: ${theme.typography.bodySmall.fontSize};
+    color: ${theme.colors.text.secondary};
+  `,
+});


### PR DESCRIPTION
Completes the Database-tab redesign (#119) — **Phase 3: the on-demand N+1 scan** (§4.3). Stacked on **#124 / `feat/database-tab-phase-2`** (base), reusing its Tempo-search + normalization + cache plumbing.

## What this adds
An **"N+1 candidates"** section below Top Queries — the *confirm* layer of the two-layer N+1 detection (§4.3). The Phase 1 queries-per-request ratio *flags* N+1-prone endpoints; this pins down the exact offender: **"endpoint X ran «normalized query» N× in one request."**

### Backend — `GET /services/{ns}/{svc}/database/nplusone`
- Bounded TraceQL candidate scan:
  `{ <svc> = "…" [&& <ns> = "…"] && span.db.system != "" } | select(span.db.statement, span.db.system, span.db.sql.table) | count() > 9`
- `count() > 9` is the candidate floor (a trace can't repeat one statement ≥10× without ≥10 DB spans). The **exact per-statement duplicate count is confirmed in Go** (`detectNPlusOne`): group each trace's DB spans by **normalized** `db.statement`, emit a finding for every fingerprint repeated **≥ 10×** in that one trace — with the endpoint (root span), repeat count, `db.system`, table, and trace link.
- **Reuses Phase 2 wholesale**: the Tempo `/api/search` proxy, `normalizeStatement` (dbnormalize.go), `clampWindow`, the SA-token / datasource-allowlist hardening, and the response cache.
- **Cost-bounded (§6)**: per-service, window clamped ≤1h, 100 candidate traces, 100 spans/trace, 25s timeout, cached. On-demand only. Tempo-unavailable → clean `unavailable` state (never hangs).
- **PII-safe (§6)**: only normalized fingerprints are returned; raw literals never leave the backend.

### Frontend — N+1 section
- On-demand **"Scan for N+1"** action (nothing runs until clicked; re-scan supported) per the PRD's cost rationale.
- Each finding: *"«endpoint» ran «query» N× (M DB spans in the request)"*, a link to the offending trace, and a **per-system remediation hint (§5)**: SQL → JOIN/batch-fetch/`IN (…)`; Redis/valkey → `MGET`/pipeline; Mongo → `$in`/aggregation; OpenSearch → bulk/multi-search; Oracle → + check plan/index.
- Clean empty / unavailable / truncated states.

## Tests
- **Backend**: grouping + threshold (below/at/multi-offender/ordered/limit), per-trace parsing (root span → endpoint, span dedupe), remediation hints per system, unconfigured-datasource guard.
- **Frontend**: on-demand (no scan until click), findings render with endpoint/repeat/trace-link/remediation, empty / unavailable / truncated states.
- `mise run all` green (837 FE tests + backend).

Refs #119. This completes the #119 Database-tab redesign.


