### PR TITLE
feat(custom-metrics): type-aware auto-charting (#68 Phase 1)

### DIFF
--- a/pkg/plugin/custommetrics.go
+++ b/pkg/plugin/custommetrics.go
@@ -25,12 +25,32 @@ const highCardinalityThreshold = 100
 // fan-out (2 queries per family, up to 50 families → peak 16 in flight).
 const customMetricEnrichConcurrency = 8
 
-// Chart hints derived from the metric type: counter→rate, histogram→p95,
-// everything else→gauge.
+// Chart hints derived from the metric type. The frontend maps each to a
+// type-aware auto-chart (#68 Phase 1):
+//   - rate    → sum(rate(X[$__rate_interval]))                       (counter)
+//   - p95     → histogram_quantile(0.95, …_bucket…)                  (histogram)
+//   - summary → throughput rate(_count) + avg rate(_sum)/rate(_count) (summary/timer)
+//   - gauge   → avg(X) aggregated across pods                         (gauge)
 const (
-	chartRate  = "rate"
-	chartP95   = "p95"
-	chartGauge = "gauge"
+	chartRate    = "rate"
+	chartP95     = "p95"
+	chartSummary = "summary"
+	chartGauge   = "gauge"
+)
+
+// familyKind classifies a collapsed metric family by its component shape.
+// It drives type inference when Mimir has no metadata (the common case on the
+// real fleet, where the metadata API returns {} for app metrics).
+type familyKind int
+
+const (
+	// familyScalar is a single-series family (counter or gauge).
+	familyScalar familyKind = iota
+	// familyHistogram has a _bucket series (classic or native/OTel histogram).
+	familyHistogram
+	// familySummary is a Micrometer summary/timer: _count+_sum siblings (and
+	// optionally a quantile base series and _max), but no _bucket.
+	familySummary
 )
 
 // CustomMetric is one discovered non-platform metric family.
@@ -120,7 +140,7 @@ func (a *App) queryCustomMetrics(ctx context.Context, namespace, service, enviro
 		return resp
 	}
 
-	families := collapseHistogramFamilies(names)
+	families := collapseFamilies(names)
 	sort.Slice(families, func(i, j int) bool { return families[i].name < families[j].name })
 	if len(families) > maxCustomMetricFamilies {
 		families = families[:maxCustomMetricFamilies]
@@ -146,18 +166,31 @@ func (a *App) queryCustomMetrics(ctx context.Context, namespace, service, enviro
 }
 
 // metricFamily is a discovered family: the logical name plus the series name
-// to count (differs for classic histograms, where _bucket series dominate).
+// to count (differs for histograms/summaries, whose component series dominate).
 type metricFamily struct {
-	name        string // logical family name (histogram base name)
-	seriesName  string // series to count for the cardinality guard
-	isHistogram bool
+	name       string     // logical family name (histogram/summary base name)
+	seriesName string     // series to count for the cardinality guard
+	kind       familyKind // scalar, histogram, or summary
 }
 
-// collapseHistogramFamilies folds classic-histogram component series
-// (X_bucket, X_sum, X_count) into a single family X when X_bucket exists.
-// A lone X_count/X_sum without X_bucket is kept as-is — it may be a real
-// counter/gauge, and guessing summary semantics here would misle the UI.
-func collapseHistogramFamilies(names map[string]bool) []metricFamily {
+// componentSuffixes are the classic-histogram/summary sidecar series that fold
+// into their base family. _max is included so Micrometer timers (which emit
+// X_max alongside X_count/X_sum) don't leave a stray gauge row (#68 Phase 1).
+var componentSuffixes = []string{"_bucket", "_sum", "_count", "_max"}
+
+// collapseFamilies folds multi-series metric families into a single logical
+// family so the UI charts them by type rather than per component series:
+//
+//   - Histograms (a _bucket series exists) collapse X_bucket/X_sum/X_count/X_max
+//     into X, typed histogram → histogram_quantile.
+//   - Micrometer summaries/timers (X_count+X_sum siblings, no _bucket) collapse
+//     X_count/X_sum/X_max — and the bare quantile series X{quantile=…} when
+//     present — into X, typed summary → throughput+avg (never quantile: there
+//     are no buckets to quantile over). This is the real-fleet shape that
+//     Phase 0 split into 3–4 mistyped gauge rows.
+//   - Everything else stays a single-series scalar family (counter or gauge),
+//     resolved later by naming heuristics.
+func collapseFamilies(names map[string]bool) []metricFamily {
 	// Base names with a _bucket series are histograms.
 	histograms := make(map[string]bool)
 	for name := range names {
@@ -165,27 +198,48 @@ func collapseHistogramFamilies(names map[string]bool) []metricFamily {
 			histograms[base] = true
 		}
 	}
+	// Base names with both _count and _sum siblings but no _bucket are
+	// summaries/timers (Micrometer's percentile-less shape).
+	summaries := make(map[string]bool)
+	for name := range names {
+		if base, ok := strings.CutSuffix(name, "_count"); ok && base != "" && !histograms[base] {
+			if names[base+"_sum"] {
+				summaries[base] = true
+			}
+		}
+	}
 
 	families := make([]metricFamily, 0, len(names))
 	seen := make(map[string]bool, len(names))
+	add := func(name, seriesName string, kind familyKind) {
+		if !seen[name] {
+			seen[name] = true
+			families = append(families, metricFamily{name: name, seriesName: seriesName, kind: kind})
+		}
+	}
+
 	for name := range names {
+		// Fold a component series (X_count, X_sum, X_max, X_bucket) into its base.
 		base := name
-		for _, suffix := range []string{"_bucket", "_sum", "_count"} {
-			if b, ok := strings.CutSuffix(name, suffix); ok && histograms[b] {
+		for _, suffix := range componentSuffixes {
+			if b, ok := strings.CutSuffix(name, suffix); ok && (histograms[b] || summaries[b]) {
 				base = b
 				break
 			}
 		}
-		if histograms[base] {
-			if !seen[base] {
-				seen[base] = true
-				families = append(families, metricFamily{name: base, seriesName: base + "_bucket", isHistogram: true})
-			}
-			continue
+		// The bare base series (Micrometer's X{quantile=…}) folds too.
+		if histograms[name] || summaries[name] {
+			base = name
 		}
-		if !seen[name] {
-			seen[name] = true
-			families = append(families, metricFamily{name: name, seriesName: name})
+
+		switch {
+		case histograms[base]:
+			add(base, base+"_bucket", familyHistogram)
+		case summaries[base]:
+			// _count is one series per label set — the right cardinality proxy.
+			add(base, base+"_count", familySummary)
+		default:
+			add(name, name, familyScalar)
 		}
 	}
 	return families
@@ -245,16 +299,44 @@ func (a *App) enrichCustomMetric(
 	return m
 }
 
-// guessMetricType applies OpenMetrics naming-convention heuristics when
-// metadata is absent: _bucket family→histogram, _total→counter, else gauge.
+// guessMetricType infers a metric type when Mimir has no metadata — the common
+// case, since the metadata API returns {} for essentially all app metrics, so
+// this heuristic path (not the metadata branch) is what actually types the
+// real fleet.
+//
+//   - Histogram/summary families are typed from their collapsed component shape.
+//   - Scalars are typed by name: monotonic-counter conventions → counter,
+//     else gauge. This fixes _total-less Micrometer counters (e.g.
+//     frontend_call_counter), which Phase 0 mistyped as gauges and charted raw
+//     instead of as a rate.
 func guessMetricType(fam metricFamily) string {
-	if fam.isHistogram {
+	switch fam.kind {
+	case familyHistogram:
 		return "histogram"
+	case familySummary:
+		return "summary"
 	}
-	if strings.HasSuffix(fam.name, "_total") {
+	if isCounterName(fam.name) {
 		return "counter"
 	}
 	return "gauge"
+}
+
+// counterSuffixes are monotonic-counter naming conventions. _total is the
+// canonical OpenMetrics suffix; _count/_counter cover the _total-less
+// Micrometer/OTel counters that land in Mimir without it (a standalone X_count
+// here is not a summary component — those were already collapsed away).
+var counterSuffixes = []string{"_total", "_count", "_counter"}
+
+// isCounterName reports whether a scalar metric name follows a counter
+// convention, so it charts as a rate rather than a raw value.
+func isCounterName(name string) bool {
+	for _, suffix := range counterSuffixes {
+		if strings.HasSuffix(name, suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 // guessMetricUnit derives a unit from conventional name suffixes/segments.
@@ -275,6 +357,8 @@ func chartForType(metricType string) string {
 		return chartRate
 	case "histogram":
 		return chartP95
+	case "summary":
+		return chartSummary
 	default:
 		return chartGauge
 	}

--- a/pkg/plugin/custommetrics_test.go
+++ b/pkg/plugin/custommetrics_test.go
@@ -200,7 +200,124 @@ func TestHandleCustomMetrics(t *testing.T) {
 			t.Errorf("_bytes unit heuristic failed: %+v", m)
 		}
 	})
+}
 
+// TestHandleCustomMetricsTypeInference covers the Phase 1 heuristic fixes:
+// _total-less counters, summary/timer collapse, and _max folding (#68).
+func TestHandleCustomMetricsTypeInference(t *testing.T) {
+	t.Run("types _total-less monotonic counters as counters (rate)", func(t *testing.T) {
+		// frontend_call_counter is the real-fleet shape Phase 0 mistyped as a
+		// gauge (charted raw) — the _counter/_count conventions fix it.
+		srv, _ := customMetricsMockServer(t, map[string][]queries.PromResult{
+			"group by (__name__)": nameResults(
+				"frontend_call_counter",
+				"cache_evictions_count",
+				"active_sessions",
+			),
+			"count({__name__=": countResult(4),
+		}, nil)
+		defer srv.Close()
+
+		app := newTestApp(t, srv.URL, defaultCaps())
+		resp := getCustomMetrics(t, app)
+
+		byName := map[string]CustomMetric{}
+		for _, m := range resp.Metrics {
+			byName[m.Name] = m
+		}
+		if m := byName["frontend_call_counter"]; m.Type != "counter" || m.Chart != "rate" {
+			t.Errorf("_counter should be a counter charted as rate: %+v", m)
+		}
+		if m := byName["cache_evictions_count"]; m.Type != "counter" || m.Chart != "rate" {
+			t.Errorf("standalone _count should be a counter charted as rate: %+v", m)
+		}
+		if m := byName["active_sessions"]; m.Type != "gauge" || m.Chart != "gauge" {
+			t.Errorf("plain scalar should stay a gauge: %+v", m)
+		}
+	})
+
+	t.Run("collapses Micrometer summaries/timers into one summary family", func(t *testing.T) {
+		// A Micrometer timer with percentiles: a quantile base series plus
+		// _count/_sum/_max sidecars and NO _bucket. Phase 0 split this into 3–4
+		// mistyped gauge rows; Phase 1 collapses it into one summary family.
+		srv, _ := customMetricsMockServer(t, map[string][]queries.PromResult{
+			"group by (__name__)": nameResults(
+				"http_server_requests_seconds",
+				"http_server_requests_seconds_count",
+				"http_server_requests_seconds_sum",
+				"http_server_requests_seconds_max",
+			),
+			"count({__name__=": countResult(8),
+		}, nil)
+		defer srv.Close()
+
+		app := newTestApp(t, srv.URL, defaultCaps())
+		resp := getCustomMetrics(t, app)
+
+		if len(resp.Metrics) != 1 {
+			t.Fatalf("expected 1 collapsed summary family, got %d: %+v", len(resp.Metrics), resp.Metrics)
+		}
+		m := resp.Metrics[0]
+		if m.Name != "http_server_requests_seconds" {
+			t.Errorf("unexpected family name: %+v", m)
+		}
+		if m.Type != "summary" || m.Chart != "summary" {
+			t.Errorf("timer should be a summary charted as throughput+avg: %+v", m)
+		}
+		// _seconds still yields a unit; the cardinality proxy is the _count series.
+		if m.Unit != "seconds" {
+			t.Errorf("expected seconds unit: %+v", m)
+		}
+	})
+
+	t.Run("collapses _max into the histogram family (no stray gauge row)", func(t *testing.T) {
+		// A Micrometer timer configured with a histogram emits _bucket AND _max.
+		// _max must fold into the histogram, not leak as a separate gauge.
+		srv, _ := customMetricsMockServer(t, map[string][]queries.PromResult{
+			"group by (__name__)": nameResults(
+				"batch_duration_seconds_bucket",
+				"batch_duration_seconds_sum",
+				"batch_duration_seconds_count",
+				"batch_duration_seconds_max",
+			),
+			"count({__name__=": countResult(40),
+		}, nil)
+		defer srv.Close()
+
+		app := newTestApp(t, srv.URL, defaultCaps())
+		resp := getCustomMetrics(t, app)
+
+		if len(resp.Metrics) != 1 {
+			t.Fatalf("expected 1 histogram family (_max folded), got %d: %+v", len(resp.Metrics), resp.Metrics)
+		}
+		if m := resp.Metrics[0]; m.Name != "batch_duration_seconds" || m.Type != "histogram" || m.Chart != "p95" {
+			t.Errorf("_max should fold into the histogram family: %+v", m)
+		}
+	})
+
+	t.Run("keeps a bare summary (no quantile series) collapsed", func(t *testing.T) {
+		// Percentile-less Micrometer timers emit only _count/_sum/_max — the
+		// bare base series never appears. Still one summary family.
+		srv, _ := customMetricsMockServer(t, map[string][]queries.PromResult{
+			"group by (__name__)": nameResults(
+				"db_query_latency_seconds_count",
+				"db_query_latency_seconds_sum",
+				"db_query_latency_seconds_max",
+			),
+			"count({__name__=": countResult(6),
+		}, nil)
+		defer srv.Close()
+
+		app := newTestApp(t, srv.URL, defaultCaps())
+		resp := getCustomMetrics(t, app)
+
+		if len(resp.Metrics) != 1 {
+			t.Fatalf("expected 1 summary family, got %d: %+v", len(resp.Metrics), resp.Metrics)
+		}
+		if m := resp.Metrics[0]; m.Name != "db_query_latency_seconds" || m.Type != "summary" {
+			t.Errorf("percentile-less timer should collapse to a summary family: %+v", m)
+		}
+	})
 }
 func TestHandleCustomMetricsGuards(t *testing.T) {
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1268,8 +1268,8 @@ export interface CustomMetric {
   series: number;
   /** Families over the series threshold are listed but not auto-charted. */
   highCardinality: boolean;
-  /** Auto-chart hint derived from the metric type. */
-  chart: 'rate' | 'p95' | 'gauge';
+  /** Auto-chart hint derived from the metric type (#68 Phase 1). */
+  chart: 'rate' | 'p95' | 'summary' | 'gauge';
 }
 
 export interface CustomMetricsResponse {

--- a/src/components/CustomMetricsPanel.test.tsx
+++ b/src/components/CustomMetricsPanel.test.tsx
@@ -2,11 +2,35 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { CustomMetricsPanel } from './CustomMetricsPanel';
+import { SceneQueryRunner } from '@grafana/scenes';
 import * as client from '../api/client';
 
 jest.mock('../api/client', () => ({
   ...jest.requireActual('../api/client'),
   getCustomMetrics: jest.fn(),
+}));
+
+// The auto-charts render an EmbeddedScene; stub @grafana/scenes so the table
+// assertions here stay focused (the per-type query PromQL is covered in
+// customMetricQueries.test.ts).
+jest.mock('@grafana/scenes', () => ({
+  EmbeddedScene: jest.fn().mockImplementation((cfg) => ({ ...cfg, Component: () => null })),
+  SceneFlexLayout: jest.fn().mockImplementation((cfg) => cfg),
+  SceneFlexItem: jest.fn().mockImplementation((cfg) => cfg),
+  SceneQueryRunner: jest.fn().mockImplementation((cfg) => cfg),
+  SceneTimeRange: jest.fn().mockImplementation((cfg) => cfg),
+  PanelBuilders: {
+    timeseries: () => {
+      const b: any = {
+        setTitle: () => b,
+        setDescription: () => b,
+        setData: () => b,
+        setUnit: () => b,
+        build: () => ({}),
+      };
+      return b;
+    },
+  },
 }));
 
 /** Extract the PromQL expr from an Explore href's JSON-encoded `left` param. */
@@ -101,8 +125,28 @@ describe('CustomMetricsPanel', () => {
       'sum(rate(orders_processed_total{app="app", namespace="team"}[$__rate_interval]))'
     );
     expect(exprFromHref(links[1].getAttribute('href'))).toBe(
-      'histogram_quantile(0.95, sum by (le) (rate(batch_duration_seconds_bucket{app="app", namespace="team"}[5m])))'
+      'histogram_quantile(0.95, sum by (le) (rate(batch_duration_seconds_bucket{app="app", namespace="team"}[$__rate_interval])))'
     );
+  });
+
+  it('auto-charts the low-cardinality families with type-aware queries when expanded', async () => {
+    const runner = SceneQueryRunner as unknown as jest.Mock;
+    runner.mockClear();
+    getCustomMetrics.mockResolvedValue({ metrics: [COUNTER, HISTOGRAM, CHATTY_GAUGE], truncated: false });
+    renderPanel();
+
+    await waitFor(() => expect(screen.getByText('Custom metrics (3)')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Custom metrics (3)'));
+    await waitFor(() => expect(screen.getByText('orders_processed_total')).toBeInTheDocument());
+
+    const exprs = runner.mock.calls.flatMap((c) => (c[0].queries as Array<{ expr: string }>).map((q) => q.expr));
+    // Counter → rate, histogram → p95.
+    expect(exprs).toContain('sum(rate(orders_processed_total{app="app", namespace="team"}[$__rate_interval]))');
+    expect(exprs).toContain(
+      'histogram_quantile(0.95, sum by (le) (rate(batch_duration_seconds_bucket{app="app", namespace="team"}[$__rate_interval])))'
+    );
+    // The high-cardinality gauge is NOT auto-charted (Explore-link only).
+    expect(exprs.some((e) => e.includes('queue_depth'))).toBe(false);
   });
 
   it('renders nothing when no custom metrics are discovered', async () => {
@@ -121,9 +165,9 @@ describe('CustomMetricsPanel', () => {
     fireEvent.click(screen.getByText('Custom metrics (1)'));
     await waitFor(() => expect(screen.getByText('queue_depth')).toBeInTheDocument());
     expect(screen.getByText(/high cardinality — not auto-charted/)).toBeInTheDocument();
-    // Gauge chart still deep-links to Explore with a sum query.
+    // Gauge chart deep-links to Explore with a pod-aggregated avg query.
     const link = screen.getByRole('link', { name: /open in explore/i });
-    expect(exprFromHref(link.getAttribute('href'))).toBe('sum(queue_depth{app="app", namespace="team"})');
+    expect(exprFromHref(link.getAttribute('href'))).toBe('avg(queue_depth{app="app", namespace="team"})');
   });
 
   it('notes truncation when the family cap was hit', async () => {

--- a/src/components/CustomMetricsPanel.tsx
+++ b/src/components/CustomMetricsPanel.tsx
@@ -1,14 +1,24 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Badge, Icon, LinkButton, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
+import {
+  EmbeddedScene,
+  PanelBuilders,
+  SceneFlexItem,
+  SceneFlexLayout,
+  SceneQueryRunner,
+  SceneTimeRange,
+} from '@grafana/scenes';
 import { CustomMetric, getCustomMetrics } from '../api/client';
 import { useFetch } from '../utils/useFetch';
 import { useTimeRange } from '../utils/timeRange';
+import { useSceneTimeSync } from '../utils/useSceneTimeSync';
 import { usePluginDatasources } from '../utils/datasources';
 import { buildMimirExploreUrl } from '../utils/explore';
 import { escapeQueryString } from '../utils/sanitize';
 import { otel } from '../otelconfig';
+import { customMetricExploreQuery, customMetricPanels } from './customMetricQueries';
 import { DataState } from './DataState';
 
 interface CustomMetricsPanelProps {
@@ -26,12 +36,15 @@ const TYPE_BADGE_COLOR: Record<string, BadgeColor> = {
 };
 
 /**
- * Zero-config custom-metric discovery (#68 Phase 0): lists a service's
- * non-platform metric families straight from Mimir — type/help/unit from the
- * metadata API (suffix heuristics as fallback), series counts as the
+ * Zero-config custom-metric discovery + auto-charting (#68 Phase 0/1): lists a
+ * service's non-platform metric families straight from Mimir — type/help/unit
+ * from the metadata API (suffix heuristics as fallback), series counts as the
  * cardinality guard — each row deep-linking to Explore with an auto-generated
- * PromQL query by metric type. Auto-charted Scenes panels are the Phase 0
- * follow-up; this section renders nothing when no custom metrics exist.
+ * PromQL query by metric type. When expanded, the non-high-cardinality families
+ * are also rendered as type-aware Scenes panels (counter→rate, histogram→p95,
+ * summary/timer→throughput+avg, gauge→pod-aggregated avg). High-cardinality
+ * families (series > 100) stay Explore-link only. Renders nothing when no
+ * custom metrics exist.
  *
  * Collapsible, default-collapsed, with the discovered-metric count in its
  * own header (IA review P9): the Overview budget is RED-first, so this
@@ -59,6 +72,9 @@ export function CustomMetricsPanel({ namespace, service, environment }: CustomMe
   }
 
   const filter = runtimeFilter(service, namespace);
+  // Auto-chart the low-cardinality families; high-cardinality ones stay
+  // Explore-link only (the series > 100 guard is the auto-chart cutoff).
+  const chartable = metrics.filter((m) => !m.highCardinality);
   // Errors are actionable feedback, not "the panel" — surface them even
   // while collapsed instead of silently hiding a failed fetch.
   const showBody = !collapsed || !!error;
@@ -77,6 +93,9 @@ export function CustomMetricsPanel({ namespace, service, environment }: CustomMe
           empty={false}
           loadingText="Discovering custom metrics…"
         >
+          {!collapsed && chartable.length > 0 && (
+            <AutoCharts metrics={chartable} filter={filter} metricsUid={metricsUid} from={from} to={to} />
+          )}
           <table className={styles.table}>
             <thead>
               <tr>
@@ -91,7 +110,7 @@ export function CustomMetricsPanel({ namespace, service, environment }: CustomMe
                 <MetricRow
                   key={m.name}
                   metric={m}
-                  exploreUrl={buildMimirExploreUrl(metricsUid, exploreQuery(m, filter), { from, to })}
+                  exploreUrl={buildMimirExploreUrl(metricsUid, customMetricExploreQuery(m, filter), { from, to })}
                 />
               ))}
             </tbody>
@@ -140,16 +159,57 @@ function runtimeFilter(service: string, namespace: string): string {
   return f;
 }
 
-/** Auto-generated PromQL by chart hint: counter→rate, histogram→p95, else gauge (#68). */
-function exploreQuery(metric: CustomMetric, filter: string): string {
-  switch (metric.chart) {
-    case 'rate':
-      return `sum(rate(${metric.name}{${filter}}[$__rate_interval]))`;
-    case 'p95':
-      return `histogram_quantile(0.95, sum by (le) (rate(${metric.name}_bucket{${filter}}[5m])))`;
-    default:
-      return `sum(${metric.name}{${filter}})`;
-  }
+/**
+ * Type-aware auto-charts for the low-cardinality families (#68 Phase 1). Each
+ * family expands to one or more timeseries panels (summaries/timers → two:
+ * throughput and avg) driven by the shared per-type PromQL. A wrapping flex
+ * grid keeps the panels compact so the section stays scannable when expanded.
+ */
+function AutoCharts({
+  metrics,
+  filter,
+  metricsUid,
+  from,
+  to,
+}: {
+  metrics: CustomMetric[];
+  filter: string;
+  metricsUid: string;
+  from: string;
+  to: string;
+}) {
+  const { fromMs, toMs } = useTimeRange();
+  const scene = useMemo(() => {
+    const items = metrics.flatMap((metric) =>
+      customMetricPanels(metric, filter).map((spec) => {
+        const runner = new SceneQueryRunner({
+          datasource: { uid: metricsUid, type: 'prometheus' },
+          queries: spec.queries.map((q) => ({ refId: q.refId, expr: q.expr, legendFormat: q.legendFormat })),
+        });
+        let builder = PanelBuilders.timeseries().setTitle(spec.title).setData(runner);
+        if (metric.help) {
+          builder = builder.setDescription(metric.help);
+        }
+        if (spec.unit) {
+          builder = builder.setUnit(spec.unit);
+        }
+        return new SceneFlexItem({ minWidth: '320px', height: 200, body: builder.build() });
+      })
+    );
+
+    return new EmbeddedScene({
+      $timeRange: new SceneTimeRange({ from, to }),
+      body: new SceneFlexLayout({ direction: 'row', wrap: 'wrap', children: items }),
+    });
+    // metricsUid/from/to/filter are the only inputs; metrics identity changes
+    // with the fetch, which is the intended rebuild trigger.
+  }, [metrics, filter, metricsUid, from, to]);
+
+  // Header refresh re-resolves fromMs/toMs while the raw strings stay put —
+  // re-query the live scene instead of rebuilding it.
+  useSceneTimeSync(scene, fromMs, toMs);
+
+  return <scene.Component model={scene} />;
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({

--- a/src/components/customMetricQueries.test.ts
+++ b/src/components/customMetricQueries.test.ts
@@ -1,0 +1,75 @@
+import { CustomMetric } from '../api/client';
+import { customMetricExploreQuery, customMetricPanels } from './customMetricQueries';
+
+const FILTER = 'app="app", namespace="team"';
+
+function metric(over: Partial<CustomMetric>): CustomMetric {
+  return { name: 'x', type: 'gauge', help: '', unit: '', series: 1, highCardinality: false, chart: 'gauge', ...over };
+}
+
+describe('customMetricPanels', () => {
+  it('charts a counter as a rate', () => {
+    const panels = customMetricPanels(
+      metric({ name: 'frontend_call_counter', type: 'counter', chart: 'rate' }),
+      FILTER
+    );
+    expect(panels).toHaveLength(1);
+    expect(panels[0].title).toBe('frontend_call_counter');
+    expect(panels[0].queries[0].expr).toBe(
+      'sum(rate(frontend_call_counter{app="app", namespace="team"}[$__rate_interval]))'
+    );
+  });
+
+  it('charts a native histogram as p95 over _bucket', () => {
+    const panels = customMetricPanels(
+      metric({ name: 'batch_duration_seconds', type: 'histogram', unit: 'seconds', chart: 'p95' }),
+      FILTER
+    );
+    expect(panels).toHaveLength(1);
+    expect(panels[0].unit).toBe('s');
+    expect(panels[0].queries[0].expr).toBe(
+      'histogram_quantile(0.95, sum by (le) (rate(batch_duration_seconds_bucket{app="app", namespace="team"}[$__rate_interval])))'
+    );
+  });
+
+  it('charts a summary/timer as throughput + avg (never quantile)', () => {
+    const panels = customMetricPanels(
+      metric({ name: 'http_server_requests_seconds', type: 'summary', unit: 'seconds', chart: 'summary' }),
+      FILTER
+    );
+    expect(panels).toHaveLength(2);
+    // Throughput panel: rate of the _count series (no unit override — it's per-second).
+    expect(panels[0].title).toContain('throughput');
+    expect(panels[0].unit).toBeUndefined();
+    expect(panels[0].queries[0].expr).toBe(
+      'sum(rate(http_server_requests_seconds_count{app="app", namespace="team"}[$__rate_interval]))'
+    );
+    // Avg panel: rate(_sum)/rate(_count), carrying the family's time unit.
+    expect(panels[1].title).toContain('avg');
+    expect(panels[1].unit).toBe('s');
+    expect(panels[1].queries[0].expr).toBe(
+      'sum(rate(http_server_requests_seconds_sum{app="app", namespace="team"}[$__rate_interval])) / sum(rate(http_server_requests_seconds_count{app="app", namespace="team"}[$__rate_interval]))'
+    );
+    // No bucket-based quantile anywhere.
+    expect(panels.some((p) => p.queries.some((q) => q.expr.includes('histogram_quantile')))).toBe(false);
+  });
+
+  it('charts a gauge as an avg aggregated across pods', () => {
+    const panels = customMetricPanels(metric({ name: 'queue_depth', type: 'gauge', chart: 'gauge' }), FILTER);
+    expect(panels).toHaveLength(1);
+    // avg() drops pod/instance labels so N pod series collapse to one line.
+    expect(panels[0].queries[0].expr).toBe('avg(queue_depth{app="app", namespace="team"})');
+  });
+});
+
+describe('customMetricExploreQuery', () => {
+  it('returns the primary panel query for the Explore deep link', () => {
+    expect(customMetricExploreQuery(metric({ name: 'q', type: 'gauge', chart: 'gauge' }), FILTER)).toBe(
+      'avg(q{app="app", namespace="team"})'
+    );
+    // For a summary the primary link is throughput (the first panel).
+    expect(customMetricExploreQuery(metric({ name: 'lat_seconds', type: 'summary', chart: 'summary' }), FILTER)).toBe(
+      'sum(rate(lat_seconds_count{app="app", namespace="team"}[$__rate_interval]))'
+    );
+  });
+});

--- a/src/components/customMetricQueries.ts
+++ b/src/components/customMetricQueries.ts
@@ -1,0 +1,116 @@
+import { CustomMetric } from '../api/client';
+
+/**
+ * Type-aware PromQL for auto-charting discovered custom metrics (#68 Phase 1).
+ *
+ * The backend infers the metric type (fixing the real-fleet mistypes: _total-less
+ * counters, and Micrometer summaries/timers that Phase 0 split into gauge rows)
+ * and hands down a `chart` hint. This module turns that hint into the actual
+ * queries, so the auto-charted Scenes panels and the "Open in Explore" deep
+ * links stay in lock-step.
+ *
+ * Query shapes by type:
+ *   - counter  → sum(rate(X[$__rate_interval]))
+ *   - histogram→ histogram_quantile(0.95, sum by(le)(rate(X_bucket[…])))
+ *   - summary  → throughput sum(rate(X_count[…])) AND avg sum(rate(X_sum[…]))/sum(rate(X_count[…]))
+ *                (never quantile — a summary/timer has no buckets)
+ *   - gauge    → avg(X) — aggregated across pods so N pod series collapse to one line
+ */
+
+/** Grafana's built-in that adapts the range vector to the panel resolution. */
+const RATE_INTERVAL = '$__rate_interval';
+
+export interface CustomMetricQuery {
+  refId: string;
+  expr: string;
+  legendFormat: string;
+}
+
+export interface CustomMetricPanelSpec {
+  /** Panel title. */
+  title: string;
+  /** Grafana unit id, when the family's unit maps to one; undefined → short. */
+  unit?: string;
+  queries: CustomMetricQuery[];
+}
+
+/** Map a discovered unit name to a Grafana unit id (undefined → no override). */
+function grafanaUnit(unit: string): string | undefined {
+  switch (unit) {
+    case 'seconds':
+      return 's';
+    case 'milliseconds':
+      return 'ms';
+    case 'bytes':
+      return 'bytes';
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Build the auto-chart panel spec(s) for one family. Summaries/timers yield two
+ * panels (throughput and average) because their units differ; every other type
+ * yields a single panel.
+ */
+export function customMetricPanels(metric: CustomMetric, filter: string): CustomMetricPanelSpec[] {
+  const n = metric.name;
+  const unit = grafanaUnit(metric.unit);
+
+  switch (metric.chart) {
+    case 'rate':
+      return [
+        {
+          title: n,
+          queries: [{ refId: 'A', expr: `sum(rate(${n}{${filter}}[${RATE_INTERVAL}]))`, legendFormat: 'rate' }],
+        },
+      ];
+    case 'p95':
+      return [
+        {
+          title: `${n} · p95`,
+          unit,
+          queries: [
+            {
+              refId: 'A',
+              expr: `histogram_quantile(0.95, sum by (le) (rate(${n}_bucket{${filter}}[${RATE_INTERVAL}])))`,
+              legendFormat: 'p95',
+            },
+          ],
+        },
+      ];
+    case 'summary':
+      return [
+        {
+          title: `${n} · throughput`,
+          queries: [
+            { refId: 'A', expr: `sum(rate(${n}_count{${filter}}[${RATE_INTERVAL}]))`, legendFormat: 'throughput' },
+          ],
+        },
+        {
+          title: `${n} · avg`,
+          unit,
+          queries: [
+            {
+              refId: 'A',
+              expr: `sum(rate(${n}_sum{${filter}}[${RATE_INTERVAL}])) / sum(rate(${n}_count{${filter}}[${RATE_INTERVAL}]))`,
+              legendFormat: 'avg',
+            },
+          ],
+        },
+      ];
+    case 'gauge':
+    default:
+      // Gauge labels include pod/instance; avg() collapses the N pod series into
+      // one line instead of N overlapping ones.
+      return [{ title: n, unit, queries: [{ refId: 'A', expr: `avg(${n}{${filter}})`, legendFormat: 'avg' }] }];
+  }
+}
+
+/**
+ * The single representative PromQL for a family's "Open in Explore" deep link —
+ * the first auto-chart query, so the table link matches what the panel shows.
+ */
+export function customMetricExploreQuery(metric: CustomMetric, filter: string): string {
+  return customMetricPanels(metric, filter)[0].queries[0].expr;
+}


### PR DESCRIPTION
Backend custom-metrics **Phase 1** (#68 / PRD #120 §A): fix type detection, then chart. Phase 0 discovered a service's non-platform metric families and deep-linked to Explore — a **table only**. This adds type-aware auto-charts and fixes the heuristics that visibly mis-charted the real fleet.

## The mandatory core: type detection
Mimir's metadata API returns `{}` for essentially all real app metrics, so type is **always** heuristic-inferred. Phase 0's heuristics misfired:

- **`_total`-less monotonic counters** (`frontend_call_counter`) were typed **gauge** → charted raw. Now `_count`/`_counter`/`_total` naming → **counter** (rate).
- **Micrometer summaries/timers** (`X_seconds{quantile=…}` + `_count`/`_sum`/`_max`, **no `_bucket`**) split into 3–4 gauge rows. Now recognized by the `_count`+`_sum`-without-`_bucket` shape and collapsed into one **summary** family.
- **`_max`** was not in the collapse set — it now folds into its histogram/summary base (no stray gauge row).

## Type-aware panels
Rendered as real Scenes panels for the **non-high-cardinality** families (the `series > 100` guard remains the auto-chart cutoff; high-card stays Explore-link only):

| type | query |
|------|-------|
| counter | `sum(rate(X{f}[$__rate_interval]))` |
| histogram | `histogram_quantile(0.95, sum by(le)(rate(X_bucket{f}[…])))` |
| summary/timer | throughput `sum(rate(X_count{f}[…]))` **and** avg `sum(rate(X_sum{f}[…]))/sum(rate(X_count{f}[…]))` (never quantile — no buckets) |
| gauge | `avg(X{f})` — aggregated across pods so N pod series collapse to one line |

Panels live in the existing collapsible, default-collapsed Custom-metrics section on Overview and render when expanded. A shared per-type query builder (`customMetricQueries.ts`) keeps panels and the "Open in Explore" links in lock-step.

## Tests
- Go: `_total`-less counter typing, summary/timer collapse (with and without the quantile base series), `_max` folding into histogram vs summary.
- TS: per-type query generation (counter/histogram/summary/gauge) + that the auto-charts wire the right queries and skip high-cardinality families.
- `mise run all` green.

## Deferred
- Curation (pin/hide) — needs the shared Postgres state backend (PRD #120 §A.4).
- Frontend Faro custom-measurement/-event sections (PRD #120 §B/C) — separate slice.

Refs #68, #120