### PR TITLE
fix(database): count Kafka consumers in queries-per-request ratio + enrich header

### DIFF
--- a/src/pages/tabs/database/scene.test.ts
+++ b/src/pages/tabs/database/scene.test.ts
@@ -100,6 +100,7 @@ describe('buildDatabaseScene', () => {
     expect(serialized).not.toContain('traces_spanmetrics_calls_total');
     expect(serialized).not.toContain('Queries per request');
     expect(serialized).not.toContain('SPAN_KIND_SERVER');
+    expect(serialized).not.toContain('SPAN_KIND_CONSUMER');
     expect(serialized).toContain('db_client_connections_wait_time_milliseconds_bucket');
   });
 
@@ -116,30 +117,56 @@ describe('buildDatabaseScene', () => {
     expect(serialized).not.toContain('Per-host breakdown');
   });
 
-  it('adds a queries-per-request ratio: db CLIENT spans divided by inbound SERVER spans', () => {
+  it('adds a queries-per-request-or-message ratio: db CLIENT spans divided by inbound SERVER or CONSUMER spans', () => {
     const scene = buildDatabaseScene(defaultParams);
     const serialized = JSON.stringify(scene!.state.body);
-    expect(serialized).toContain('Queries per request');
-    // Denominator selects inbound SERVER spans (HTTP + gRPC).
-    expect(serialized).toContain('SPAN_KIND_SERVER');
+    expect(serialized).toContain('Queries per request or message');
+    // Denominator selects inbound work: SERVER spans (HTTP/gRPC) OR CONSUMER
+    // spans (Kafka messages), via a regex match — so Kafka-driven apps get a
+    // real ratio instead of N/A.
+    expect(serialized).toContain('span_kind=~\\"SPAN_KIND_SERVER|SPAN_KIND_CONSUMER\\"');
     // Numerator is the same CLIENT db-span rate the Rate panel sums.
     expect(serialized).toMatch(
       /sum\(rate\(traces_spanmetrics_calls_total\{[^}]*SPAN_KIND_CLIENT[^}]*\}\[\$__rate_interval\]\)\)/
     );
   });
 
-  it('guards the ratio against divide-by-zero so non-HTTP services read N/A instead of +Inf', () => {
+  it('guards the ratio against divide-by-zero so no-inbound (batch) services get a no-value state instead of +Inf', () => {
     const scene = buildDatabaseScene(defaultParams);
     const serialized = JSON.stringify(scene!.state.body);
     // `sum(db) / (sum(inbound) > 0)` — the `> 0` filter drops the series when a
-    // service has no inbound SERVER spans (batch jobs, pure Kafka consumers) or
-    // a zero request rate in-window, leaving the stat empty (rendered as N/A)
-    // rather than dividing by zero.
+    // service has genuinely no inbound SERVER *or* CONSUMER spans (pure batch
+    // jobs) or a zero rate in-window, leaving the stat empty rather than
+    // dividing by zero.
     expect(serialized).toMatch(
-      /\/ \(sum\(rate\(traces_spanmetrics_calls_total\{[^}]*SPAN_KIND_SERVER[^}]*\}\[\$__rate_interval\]\)\) > 0\)/
+      /\/ \(sum\(rate\(traces_spanmetrics_calls_total\{[^}]*SPAN_KIND_SERVER\|SPAN_KIND_CONSUMER[^}]*\}\[\$__rate_interval\]\)\) > 0\)/
     );
-    // The stat surfaces the empty result as an explicit N/A rather than "No data".
-    expect(serialized).toContain('N/A');
+    // The empty result renders an explanatory no-inbound message, not a bare N/A.
+    expect(serialized).toContain('no inbound requests or messages');
+  });
+
+  it('shows a Query-rate companion stat (raw db throughput) so no-inbound batch jobs still have a meaningful header', () => {
+    const scene = buildDatabaseScene(defaultParams);
+    const serialized = JSON.stringify(scene!.state.body);
+    expect(serialized).toContain('Query rate');
+    // A bare summed db call rate — always populated for a db-emitting service,
+    // independent of any inbound denominator.
+    expect(serialized).toMatch(
+      /sum\(rate\(traces_spanmetrics_calls_total\{[^}]*SPAN_KIND_CLIENT[^}]*db_system[^}]*\}\[\$__rate_interval\]\)\)/
+    );
+  });
+
+  it('shows Errors% and P95 companion stats mirroring the RED panels as single values', () => {
+    const scene = buildDatabaseScene(defaultParams);
+    const serialized = JSON.stringify(scene!.state.body);
+    // Errors% single value keeps the `or ... * 0` zero-fill so it reads 0%, not empty.
+    expect(serialized).toMatch(
+      /\* 100 or sum\(rate\(traces_spanmetrics_calls_total\{[^}]*\}\[\$__rate_interval\]\)\) \* 0/
+    );
+    // P95 single value (no db_system grouping — a single header number).
+    expect(serialized).toMatch(
+      /histogram_quantile\(0\.95, sum by \(le\) \(rate\(traces_spanmetrics_duration_milliseconds_bucket\{[^}]*\}\[\$__rate_interval\]\)\)\)/
+    );
   });
 
   it('omits the connection-acquisition panels when hasDbPool is false (the default)', () => {

--- a/src/pages/tabs/database/scene.ts
+++ b/src/pages/tabs/database/scene.ts
@@ -72,17 +72,30 @@ export function buildDbTracesExploreUrl(tracesUid: string, service: string, name
  * fpinntektsmelding (postgresql, ~8.6 calls/s). Rate, duration P95,
  * and (zero-filled) error panels all return data for all three.
  *
- * Queries-per-request ratio (per Database-tab redesign PRD, issue #119):
- * database operations per inbound request. Numerator is the same outbound
- * CLIENT db-span rate the Rate panel sums; denominator is the inbound
- * SERVER-span rate for the service (covers HTTP *and* gRPC — a superset of
- * the PRD's http_server_request_count). Kept on the tab's existing
- * span-metrics source rather than the raw db_client_operation_/http_server_
- * metric families so the label conventions (service_name/namespace/env) stay
- * consistent with the RED panels. A `> 0` guard on the denominator drops the
- * series when the service has no inbound requests (batch jobs, pure Kafka
- * consumers) or its request rate is zero in-window, so the stat reads N/A
- * instead of dividing by zero. A high value flags an N+1 pattern.
+ * Queries-per-request-or-message ratio (per Database-tab redesign PRD, issue
+ * #119): database operations per inbound unit of work. Numerator is the same
+ * outbound CLIENT db-span rate the Rate panel sums; denominator is the inbound
+ * SERVER *or* CONSUMER span rate for the service — i.e. HTTP/gRPC requests *or*
+ * consumed Kafka messages. The original SERVER-only denominator read N/A for
+ * the many nais apps that are Kafka-driven rather than HTTP servers (verified
+ * 2026-07-06 against prod Mimir: spenn/tbd has an empty SERVER rate but a
+ * ~60/s CONSUMER rate and ~0.08/s db calls → a real ~0.0015 queries/message
+ * once consumers are counted). Kept on the tab's existing span-metrics source
+ * rather than the raw db_client_operation_/http_server_ metric families so the
+ * label conventions (service_name/namespace/env) stay consistent with the RED
+ * panels. A `> 0` guard on the denominator drops the series when the service
+ * has genuinely no inbound work at all (pure batch jobs, e.g.
+ * aareg-mottak-opptjeningsgrunnlag/arbeidsforhold: no SERVER and no CONSUMER
+ * spans, ~9/s db calls) rather than dividing by zero. A high value flags an
+ * N+1 pattern.
+ *
+ * The top row is a compact stat strip so it stays informative for all three
+ * app shapes (HTTP server, Kafka consumer, pure batch): the ratio sits
+ * alongside an always-present Query-rate stat plus Errors% and P95 companions.
+ * When the ratio has no denominator (batch jobs) it renders an explicit
+ * "no inbound requests or messages" no-value state instead of a lone bare N/A,
+ * and the neighbouring Query-rate stat still shows the raw db throughput — so
+ * the header never reads as broken.
  *
  * (The per-host `server_address` breakdown was removed in the #119 redesign:
  * "which database host served this" is a DBA/infra concern, not something an
@@ -140,9 +153,12 @@ export function buildDatabaseScene(params: BuildDatabaseSceneParams): EmbeddedSc
   // criteria the backend uses to classify "database" endpoints (see
   // EndpointGroups.database in api/client.ts).
   const dbFilter = `${svcFilter}, ${otel.labels.spanKind}="${otel.spanKinds.client}", ${otel.labels.dbSystem}=~".+"`;
-  // Inbound requests: SERVER-kind spans for this service (HTTP + gRPC). Used as
-  // the denominator of the queries-per-request ratio.
-  const serverFilter = `${svcFilter}, ${otel.labels.spanKind}="${otel.spanKinds.server}"`;
+  // Inbound work: SERVER-kind spans (HTTP + gRPC requests) *or* CONSUMER-kind
+  // spans (Kafka messages consumed). Used as the denominator of the
+  // queries-per-request-or-message ratio. Broadened from SERVER-only so
+  // Kafka-driven apps (the majority of nais workloads) get a real ratio
+  // instead of N/A.
+  const inboundFilter = `${svcFilter}, ${otel.labels.spanKind}=~"${otel.spanKinds.server}|${otel.spanKinds.consumer}"`;
   const panelDurationUnit = durationUnit === 's' ? 's' : 'ms';
 
   const rateQuery = new SceneQueryRunner({
@@ -192,10 +208,11 @@ export function buildDatabaseScene(params: BuildDatabaseSceneParams): EmbeddedSc
     ],
   });
 
-  // Queries-per-request ratio — the always-on N+1 smell (PRD #119 §4.1).
-  // db operations ÷ inbound requests. The `> 0` guard on the denominator makes
-  // the expression empty (→ stat reads N/A) for services with no inbound
-  // SERVER spans, rather than producing +Inf from a divide-by-zero.
+  // Queries-per-request-or-message ratio — the always-on N+1 smell (PRD #119
+  // §4.1). db operations ÷ inbound requests-or-messages. The `> 0` guard on the
+  // denominator makes the expression empty (→ stat shows its no-inbound state)
+  // for services with no inbound SERVER *or* CONSUMER spans, rather than
+  // producing +Inf from a divide-by-zero.
   const ratioQuery = new SceneQueryRunner({
     datasource: { uid: metricsUid, type: 'prometheus' },
     minInterval: '5m',
@@ -204,7 +221,50 @@ export function buildDatabaseScene(params: BuildDatabaseSceneParams): EmbeddedSc
         refId: 'A',
         expr:
           `sum(rate(${callsMetric}{${dbFilter}}[$__rate_interval])) ` +
-          `/ (sum(rate(${callsMetric}{${serverFilter}}[$__rate_interval])) > 0)`,
+          `/ (sum(rate(${callsMetric}{${inboundFilter}}[$__rate_interval])) > 0)`,
+      },
+    ],
+  });
+
+  // Companion header stats (always meaningful, even when the ratio is empty).
+  // Query rate: raw outbound db throughput — present for every db-emitting app,
+  // so batch jobs with no inbound work still get an informative header number.
+  const queryRateStatQuery = new SceneQueryRunner({
+    datasource: { uid: metricsUid, type: 'prometheus' },
+    minInterval: '5m',
+    queries: [
+      {
+        refId: 'A',
+        expr: `sum(rate(${callsMetric}{${dbFilter}}[$__rate_interval]))`,
+      },
+    ],
+  });
+
+  // Errors %: single-value mirror of the RED error panel. Same `or ... * 0`
+  // zero-fill so it reads 0% rather than an empty "No data" when there are no
+  // error samples in-window.
+  const errorRateStatQuery = new SceneQueryRunner({
+    datasource: { uid: metricsUid, type: 'prometheus' },
+    minInterval: '5m',
+    queries: [
+      {
+        refId: 'A',
+        expr:
+          `sum(rate(${callsMetric}{${dbFilter}, ${otel.labels.statusCode}="${otel.statusCodes.error}"}[$__rate_interval])) ` +
+          `/ sum(rate(${callsMetric}{${dbFilter}}[$__rate_interval])) * 100 ` +
+          `or sum(rate(${callsMetric}{${dbFilter}}[$__rate_interval])) * 0`,
+      },
+    ],
+  });
+
+  // P95: single-value mirror of the RED duration panel, in the tab's duration unit.
+  const p95StatQuery = new SceneQueryRunner({
+    datasource: { uid: metricsUid, type: 'prometheus' },
+    minInterval: '5m',
+    queries: [
+      {
+        refId: 'A',
+        expr: `histogram_quantile(0.95, sum by (${otel.labels.le}) (rate(${durationBucket}{${dbFilter}}[$__rate_interval])))`,
       },
     ],
   });
@@ -271,28 +331,77 @@ export function buildDatabaseScene(params: BuildDatabaseSceneParams): EmbeddedSc
           ? [
               new SceneFlexItem({
                 height: 120,
-                width: 300,
-                body: PanelBuilders.stat()
-                  .setTitle('Queries per request')
-                  .setDescription(
-                    'Database operations per inbound request (outbound db CLIENT spans ÷ inbound SERVER spans). ' +
-                      'A high value is the classic N+1 smell — many small queries where a single JOIN or batch-fetch ' +
-                      'would do; use "View DB traces" above to inspect the offending requests. Reads N/A for services ' +
-                      'with no inbound requests (e.g. batch jobs or pure Kafka consumers).'
-                  )
-                  .setData(ratioQuery)
-                  .setUnit('none')
-                  .setDecimals(1)
-                  .setNoValue('N/A')
-                  .setThresholds({
-                    mode: ThresholdsMode.Absolute,
-                    steps: [
-                      { value: null as unknown as number, color: 'green' },
-                      { value: 20, color: 'orange' },
-                      { value: 50, color: 'red' },
-                    ],
-                  })
-                  .build(),
+                body: new SceneFlexLayout({
+                  direction: 'row',
+                  children: [
+                    new SceneFlexItem({
+                      body: PanelBuilders.stat()
+                        .setTitle('Queries per request or message')
+                        .setDescription(
+                          'Database operations per inbound unit of work — outbound db CLIENT spans ÷ inbound ' +
+                            'SERVER (HTTP/gRPC request) or CONSUMER (Kafka message) spans. A high value is the ' +
+                            'classic N+1 smell — many small queries where a single JOIN or batch-fetch would do; ' +
+                            'use "View DB traces" above to inspect the offending requests. Shows "no inbound ' +
+                            'requests or messages" for pure batch jobs with no inbound spans in the window — read ' +
+                            'the Query rate stat beside it for their raw throughput.'
+                        )
+                        .setData(ratioQuery)
+                        .setUnit('none')
+                        .setDecimals(1)
+                        .setNoValue('no inbound requests or messages')
+                        .setThresholds({
+                          mode: ThresholdsMode.Absolute,
+                          steps: [
+                            { value: null as unknown as number, color: 'green' },
+                            { value: 20, color: 'orange' },
+                            { value: 50, color: 'red' },
+                          ],
+                        })
+                        .build(),
+                    }),
+                    new SceneFlexItem({
+                      body: PanelBuilders.stat()
+                        .setTitle('Query rate')
+                        .setDescription(
+                          'Total outbound database call rate (all db systems). Always populated for a ' +
+                            'db-emitting service, so the header stays meaningful even for batch jobs where the ' +
+                            'queries-per-request ratio is undefined.'
+                        )
+                        .setData(queryRateStatQuery)
+                        .setUnit('reqps')
+                        .setDecimals(2)
+                        .setNoValue('N/A')
+                        .build(),
+                    }),
+                    new SceneFlexItem({
+                      body: PanelBuilders.stat()
+                        .setTitle('Errors')
+                        .setDescription('Percentage of database calls resulting in an error status (all db systems).')
+                        .setData(errorRateStatQuery)
+                        .setUnit('percent')
+                        .setDecimals(2)
+                        .setNoValue('N/A')
+                        .setThresholds({
+                          mode: ThresholdsMode.Absolute,
+                          steps: [
+                            { value: null as unknown as number, color: 'green' },
+                            { value: 1, color: 'orange' },
+                            { value: 5, color: 'red' },
+                          ],
+                        })
+                        .build(),
+                    }),
+                    new SceneFlexItem({
+                      body: PanelBuilders.stat()
+                        .setTitle('Duration (P95)')
+                        .setDescription('P95 database call latency across all db systems.')
+                        .setData(p95StatQuery)
+                        .setUnit(panelDurationUnit)
+                        .setNoValue('N/A')
+                        .build(),
+                    }),
+                  ],
+                }),
               }),
               new SceneFlexItem({
                 body: new SceneFlexLayout({

--- a/src/pages/tabs/database/scene.ts
+++ b/src/pages/tabs/database/scene.ts
@@ -213,6 +213,23 @@ export function buildDatabaseScene(params: BuildDatabaseSceneParams): EmbeddedSc
   // denominator makes the expression empty (→ stat shows its no-inbound state)
   // for services with no inbound SERVER *or* CONSUMER spans, rather than
   // producing +Inf from a divide-by-zero.
+  //
+  // KNOWN LIMITATION — inflated ratio for scheduler/timer-driven apps.
+  // The denominator only counts inbound SERVER (HTTP/gRPC) and CONSUMER (Kafka)
+  // spans. Work kicked off by an in-process scheduler or timer roots at a
+  // SPAN_KIND_INTERNAL span, which is in *neither* the numerator nor the
+  // denominator. If such an app also happens to serve a trickle of inbound
+  // traffic, its db-client rate is divided by that tiny inbound rate and the
+  // ratio balloons into a false "severe N+1". Live example (prod Mimir,
+  // 2026-07-06): fpinntektsmelding runs ~8.9 db calls/s but only ~0.0037
+  // inbound/s → ~2400, which is a scheduling artifact, not an N+1. The `> 0`
+  // guard only rejects an *exactly-empty* denominator; a tiny-but-nonzero one
+  // passes straight through. For these apps the always-present Query-rate
+  // companion stat below is the honest signal, not the ratio. Flooring the
+  // denominator (require inbound ≥ a small threshold before showing the ratio)
+  // or a relative guard (gate on inbound being a meaningful fraction of the db
+  // rate) is a deliberate future refinement — tracked in
+  // https://github.com/nais/grafana-apm-app/issues/132.
   const ratioQuery = new SceneQueryRunner({
     datasource: { uid: metricsUid, type: 'prometheus' },
     minInterval: '5m',


### PR DESCRIPTION
## Problem

The Database tab's **Queries per request** stat computed
`sum(rate(calls{db CLIENT})) / (sum(rate(calls{SERVER})) > 0)` — the denominator
only matched `span_kind="SPAN_KIND_SERVER"`. Most nais apps aren't HTTP servers,
so their SERVER rate is empty and the ratio read a dead **N/A** even while they
run plenty of queries. Diagnosed against live prod Mimir (`X-Scope-OrgID: tenant`):

| App | Shape | SERVER | CONSUMER | db calls | Old ratio |
|---|---|---|---|---|---|
| `spenn` (tbd) | Kafka consumer | empty | ~60/s | ~0.07/s | **N/A** |
| `aareg-mottak-opptjeningsgrunnlag` (arbeidsforhold) | pure batch | empty | empty | ~6/s | genuinely undefined |
| `pdl-api` (pdl) | HTTP + mongodb | ~35/s | ~0 | ~60/s | computes |

The RED panels were fine; only the ratio denominator was wrong.

## Changes (all in the Database tab scene + its test)

1. **Broadened the denominator** from `SPAN_KIND_SERVER` to a regex over
   **SERVER or CONSUMER** — HTTP/gRPC requests *or* consumed Kafka messages.
   Retitled to *Queries per request or message*.
2. **No dead N/A for batch apps.** Replaced the lone stat with a compact header
   stat row so the top is always meaningful for all three app shapes. An
   always-present **Query rate** stat (raw summed db throughput) sits beside the
   ratio, and the ratio's empty state now renders an explanatory
   *"no inbound requests or messages"* instead of a bare N/A.
3. **Companion stats:** Query rate (`reqps`), Errors % (zero-filled single value),
   and P95 (tab's duration unit) alongside the ratio.

## Live verification (prod Mimir, `X-Scope-OrgID: tenant`, 5m windows)

**Kafka consumer — `spenn` (tbd):** now a real number, not N/A.
```
sum(rate(calls{...spenn,tbd,CLIENT,db_system=~".+"}[5m]))
  / (sum(rate(calls{...spenn,tbd,span_kind=~"SPAN_KIND_SERVER|SPAN_KIND_CONSUMER"}[5m])) > 0)
  -> ~0.0011  (queries per message; CONSUMER rate ~62/s)
```

**Batch / no inbound — `aareg-mottak-opptjeningsgrunnlag` (arbeidsforhold):**
ratio stays undefined (-> no-inbound state), Query-rate companion shows throughput.
```
SERVER|CONSUMER rate -> EMPTY
sum(rate(calls{...CLIENT,db_system=~".+"}[5m]))  -> ~6.2  (Query rate, reqps)
ratio -> EMPTY  (renders "no inbound requests or messages")
```

**Genuine HTTP app — `pdl-api` (pdl, mongodb):** the ratio computes correctly
against real inbound traffic.
```
db ~60.8/s ÷ inbound ~34.6/s -> 1.76 queries/request  ✅
```

Errors % returned `0` (zero-filled) and P95 (`latency_bucket`) returned sensible
values (~1.6-4 ms) for the verified apps.

## Known limitation (not fixed here — tracked in #132)

For **scheduler/timer-driven** apps, DB work roots at a `SPAN_KIND_INTERNAL`
span that is in *neither* the numerator nor the denominator. If such an app also
serves a trickle of inbound traffic, the ratio inflates into a false "severe
N+1": e.g. `fpinntektsmelding` (teamforeldrepenger) runs ~9 db calls/s against
~0.004 inbound/s → **~2180**, which is a scheduling artifact, not an N+1. The
`> 0` guard only rejects an *exactly-empty* denominator; a tiny-but-nonzero one
passes through. For these apps the always-present **Query rate** companion is the
honest signal. Flooring the denominator (or a relative guard) is a deliberate
future refinement — tracked in
[#132](https://github.com/nais/grafana-apm-app/issues/132), with a code comment
by the ratio query pointing to it. This PR is still a strict improvement over the
prior SERVER-only behavior (which read a dead N/A for every Kafka app).

## Test / build

`mise run all` (frontend check + typecheck + lint + prettier + 851 tests +
backend check + production build) passes. Database scene test file: 24 tests
green, updated for the new denominator regex, no-value text, and companion stats.
